### PR TITLE
Fix/12 allow few tags Closes #12

### DIFF
--- a/immich_autotag/tags/print_tags.py
+++ b/immich_autotag/tags/print_tags.py
@@ -11,8 +11,3 @@ def print_tags(tag_collection: TagCollectionWrapper) -> None:
     for tag in tag_collection:
         print(f"- {tag.name}")
     print(f"Total tags: {len(tag_collection)}\n")
-    MIN_TAGS = 57
-    if len(tag_collection) < MIN_TAGS:
-        raise Exception(
-            f"ERROR: Unexpectedly low number of tags: {len(tag_collection)} < {MIN_TAGS}"
-        )


### PR DESCRIPTION
My apologies for this one. This check was a leftover from the debugging phase, and I completely overlooked how it would break small or new installations.

This PR removes the hard-coded MIN_TAGS validation to allow the tool to run regardless of the library size. Fixed in #12.