### PR TITLE
Fix Spanish character in release command breaking Quality Gate

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -2,7 +2,7 @@ Execute a release for immich-autotag.
 
 ## Steps
 
-1. If the user provided a version number as argument, use it. Otherwise ask: "¿Qué versión quieres publicar? (actual: `cat pyproject.toml | grep ^version`)"
+1. If the user provided a version number as argument, use it. Otherwise ask: "Which version do you want to publish? (current: `cat pyproject.toml | grep ^version`)"
 
 2. Check preconditions:
    - Run `git status` — abort if there are uncommitted changes.


### PR DESCRIPTION
## Summary

- The `/release` command prompt contained a Spanish question (`¿Qué versión quieres publicar?`) that triggered the `check_no_spanish_chars` Quality Gate check.
- Replaced with English equivalent: `Which version do you want to publish?`

## Test plan

- [x] Quality Gate passes locally (`check_no_spanish_chars: OK`, all 15 checks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)