### PR TITLE
Release v0.81.0: permission drift detection + checkpoint wrap-around + Jenkins auto-chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,3 +119,23 @@ Working documentation for features, bugs, and design decisions lives under `docs
 ## Project-level skills (`.claude/commands/`)
 
 Project-specific slash commands can be added as Markdown files under `.claude/commands/`. They are available as `/command-name` in Claude Code and are committed to the repo so all contributors share them.
+
+## Working with the maintainer
+
+These rules are explicit project policy because the maintainer (txemi) has had to repeat them across sessions on multiple machines/users. Treat them as absolute, on top of the general system instructions.
+
+### Git: never commit or push without explicit authorization in the same turn
+
+- **Never run `git commit`** without an explicit instruction in the SAME turn ("commit", "haz el commit", "make the commit", or equivalent). An authorisation given in an earlier turn does NOT carry over: every commit needs fresh confirmation.
+- **Never run `git push`** without explicit instruction in the same turn. Push is even stricter than commit.
+- Speech-to-text input is unreliable: words like "cómic" / "comics" are almost always "commit" — interpret them as commit. But the rule about explicit authorisation still applies; if the intent is unclear, ask.
+- `git add` / staging is fine without explicit permission as preparation for a commit, but stop before `git commit`.
+- After file edits, the default flow is: summarise the change, optionally show the diff, then ask "¿hago el commit?" or equivalent. Wait for the answer.
+
+### Auto mode does not relax git rules
+
+Auto mode allows acting on low-risk reversible work without confirmation. Commits and pushes are NOT in that bucket because they affect git history, which is shared state. The git rules above override auto mode.
+
+### Scope discipline
+
+Don't expand the scope of a task without asking. If the maintainer asks to fix X, don't take the opportunity to refactor Y "while you're there".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Current Focus (2026-04-26)
+## Current Focus (2026-04-27)
 
-Active work is on branch `fix/conversion-album-move`. Two things are in progress simultaneously:
+Active work is on branch `ops/batch-processing` (the predecessor `fix/conversion-album-move`
+was merged into main as PR #57 and released as `v0.80.10`). Two things are in progress:
 
 1. **Batch processing run** — Jenkins is executing sequential 30 000-asset batches to
-   process the full library. Each run resumes via checkpoint.
+   process the full library on `ops/batch-processing`. Each run resumes via checkpoint.
+   The chain restarts once on the new branch (one-time `skip_n=0`) and chains forward
+   from there.
    → Read before touching CI or the stats/perf code:
    [`docs/issues/0031-cicd/subtasks/0012-jenkins/subtasks/004-active-run-monitoring/ai-context.md`](docs/issues/0031-cicd/subtasks/0012-jenkins/subtasks/004-active-run-monitoring/ai-context.md)
 
-2. **Bug — temp-unclassified albums for already-classified assets** — fix implemented,
-   pending review. Assets that underwent a MOVE conversion lost their classification
-   signal and were incorrectly placed in temp albums.
+2. **Bug — temp-unclassified albums for already-classified assets** — under observation.
+   First-layer fix is in main; a second-layer fix exists locally on `ops/batch-processing`
+   but is intentionally not committed until sequential runs confirm it is needed.
    → Read before touching conversion, classification, or temp-album logic:
    [`docs/issues/0024-album-features/subtasks/0016-auto-album-creation/subtasks/004-temp-album-false-positive-classified-assets/ai-context.md`](docs/issues/0024-album-features/subtasks/0016-auto-album-creation/subtasks/004-temp-album-false-positive-classified-assets/ai-context.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,11 +126,11 @@ These rules are explicit project policy because the maintainer (txemi) has had t
 
 ### Git: never commit or push without explicit authorization in the same turn
 
-- **Never run `git commit`** without an explicit instruction in the SAME turn ("commit", "haz el commit", "make the commit", or equivalent). An authorisation given in an earlier turn does NOT carry over: every commit needs fresh confirmation.
+- **Never run `git commit`** without an explicit instruction in the SAME turn ("commit", "go ahead and commit", "make the commit", or equivalent). An authorisation given in an earlier turn does NOT carry over: every commit needs fresh confirmation.
 - **Never run `git push`** without explicit instruction in the same turn. Push is even stricter than commit.
-- Speech-to-text input is unreliable: words like "cómic" / "comics" are almost always "commit" — interpret them as commit. But the rule about explicit authorisation still applies; if the intent is unclear, ask.
+- The maintainer's speech-to-text sometimes mistranscribes "commit"; interpret obvious typos accordingly. The explicit-authorisation rule still applies; if intent is unclear, ask.
 - `git add` / staging is fine without explicit permission as preparation for a commit, but stop before `git commit`.
-- After file edits, the default flow is: summarise the change, optionally show the diff, then ask "¿hago el commit?" or equivalent. Wait for the answer.
+- After file edits, the default flow is: summarise the change, optionally show the diff, then ask "do I commit?" or equivalent. Wait for the answer.
 
 ### Auto mode does not relax git rules
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,12 @@ def tagBuild(String type) {
 }
 pipeline {
     options {
-        // Keep only the last 4 builds
-        buildDiscarder(logRotator(numToKeepStr: '4'))
+        // Keep last 30 builds or 30 days, whichever is smaller. The previous
+        // value of 4 was effectively bypassed because every SUCCESS build was
+        // pinned via `currentBuild.keepLog = true` (now removed in the
+        // success post-action below), so old builds never rotated and ate
+        // tens of GB on the master.
+        buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '30'))
     }
     agent {
         docker {
@@ -141,8 +145,10 @@ pipeline {
         success {
             echo "✅ Pipeline succeeded - All stages passed"
             script {
-                currentBuild.keepLog = true
-                echo "🔒 Build marked as 'Keep this build forever' (success)"
+                // Do NOT pin successful builds with keepLog=true. Pinning bypasses
+                // buildDiscarder and historical builds accumulate forever, filling
+                // the master disk (we hit 99% in May 2026). If a specific build
+                // needs to be retained, mark it manually from the UI instead.
                 if (ENABLE_JENKINS_TAGGING) {
                     tagBuild('success')
                 } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 // ==================== CONFIG FLAGS ====================
 def ENABLE_JENKINS_TAGGING = true // Set to true to enable GitHub tagging
+def ENABLE_AUTO_CHAIN = true      // Set to true to auto-trigger the next build on success
+                                  // (keeps the batch-processing chain self-perpetuating
+                                  // without external dispatch). Failure stops the chain
+                                  // by design — re-enable manually after investigating.
 
 // Helper for tagging (debe estar fuera del pipeline)
 def tagBuild(String type) {
@@ -160,6 +164,12 @@ pipeline {
                     tagBuild('success')
                 } else {
                     echo "[INFO] Jenkins tagging and push is disabled by ENABLE_JENKINS_TAGGING flag."
+                }
+                if (ENABLE_AUTO_CHAIN) {
+                    echo "🔁 Auto-chain enabled: triggering next build on this branch"
+                    build job: env.JOB_NAME, wait: false, propagate: false
+                } else {
+                    echo "[INFO] Auto-chain disabled by ENABLE_AUTO_CHAIN flag."
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,8 +137,15 @@ pipeline {
     
     post {
         always {
-            // Archive run outputs (logs, reports, links) generated per execution, excluding albums cache
-            archiveArtifacts artifacts: 'logs_local/**/*', excludes: 'logs_local/*/api_cache/*/**', fingerprint: true, allowEmptyArchive: true
+            // Archive run-dir outputs only. Two changes vs the previous pattern:
+            //   * `*_PID*` matches the run dir naming scheme and skips `_archive/`,
+            //     which the wrap-around fills with snapshots of completed cycles
+            //     and grows unbounded over time.
+            //   * `fingerprint: false` — SHA1ing all run files dominated build wall
+            //     time (5-47h per build for the post-actions phase). We don't
+            //     consume these artifacts across pipelines, so the fingerprints
+            //     have no consumer.
+            archiveArtifacts artifacts: 'logs_local/*_PID*/**', excludes: 'logs_local/*/api_cache/**', fingerprint: false, allowEmptyArchive: true
             echo "Pipeline execution completed at ${new Date()}"
         }
 

--- a/docs/issues/0031-cicd/subtasks/0012-jenkins/subtasks/004-active-run-monitoring/ai-context.md
+++ b/docs/issues/0031-cicd/subtasks/0012-jenkins/subtasks/004-active-run-monitoring/ai-context.md
@@ -1,6 +1,19 @@
 # Active Run Monitoring — ai-context
 
-**Last verified:** 2026-04-26
+**Last verified:** 2026-04-27
+
+## Branch in use
+
+Active branch: **`ops/batch-processing`**
+
+The previous branch `fix/conversion-album-move` was merged to main (PR #57) and released
+as `v0.80.10` on 2026-04-27. Operational batch runs were moved to a dedicated branch so
+the `fix/*` namespace is not abused as a long-lived ops home. The first build on
+`ops/batch-processing` starts with `skip_n=0` (one-time chain reset, ~1-2h overhead)
+and chains forward from there.
+
+The historical Jenkins job for `fix/conversion-album-move` remains accessible until the
+multibranch orphan strategy purges it.
 
 ## Operational record (private repo)
 
@@ -94,7 +107,7 @@ only one build runs at a time. This makes runs deterministic and fully reproduci
 
 ## What we are tracking
 
-Branch `fix/conversion-album-move` is being executed sequentially by Jenkins.
+Branch `ops/batch-processing` is being executed sequentially by Jenkins.
 Each run should:
 - Process exactly `max_assets = 30 000` assets
 - Resume from the checkpoint left by the previous run (`resume_previous = true`, overlap = 100)

--- a/immich_autotag/albums/album/album_dto_state.py
+++ b/immich_autotag/albums/album/album_dto_state.py
@@ -242,8 +242,12 @@ class AlbumDtoState:
         if self._load_source != AlbumLoadSource.DETAIL:
             raise RuntimeError("Cannot get asset UUIDs from SEARCH/partial album DTO.")
         if self._asset_uuids_cache is None:
-            from immich_autotag.types.uuid_wrappers import AssetUUID
-
+            # AssetUUID is already imported at module scope (line 11).
+            # A local `from ... import AssetUUID` here would shadow that module-level
+            # binding and make AssetUUID a *local* variable for the whole function;
+            # then typeguard's evaluation of the `set[AssetUUID]` return annotation
+            # (under conditional_typechecked) raises UnboundLocalError on the cached
+            # code path, where the import line is skipped.
             self._asset_uuids_cache = set(
                 AssetUUID.from_uuid(UUID(a.id)) for a in self._dto.assets
             )

--- a/immich_autotag/albums/album/album_dto_state.py
+++ b/immich_autotag/albums/album/album_dto_state.py
@@ -58,6 +58,16 @@ class AlbumDtoState:
 
     _max_age_seconds: int = DEFAULT_CACHE_MAX_AGE_SECONDS
 
+    # Lazy cache for the asset UUID set: get_asset_uuids() is called many times
+    # per processed asset (e.g. via has_asset_wrapper before each add). Building
+    # the set from `self._dto.assets` is O(N) per call, with N up to ~100k for
+    # the largest albums; typeguard validation of every UUID dominates CPU.
+    # The state is effectively immutable (the DTO does not mutate after load),
+    # so caching the set is safe within the lifetime of this state instance.
+    _asset_uuids_cache: "set[AssetUUID] | None" = attrs.field(
+        default=None, init=False, eq=False, repr=False
+    )
+
     def __attrs_post_init__(self):
         # _dto is always required and validated by attrs; no need to check for None
         pass
@@ -231,9 +241,13 @@ class AlbumDtoState:
         """
         if self._load_source != AlbumLoadSource.DETAIL:
             raise RuntimeError("Cannot get asset UUIDs from SEARCH/partial album DTO.")
-        from immich_autotag.types.uuid_wrappers import AssetUUID
+        if self._asset_uuids_cache is None:
+            from immich_autotag.types.uuid_wrappers import AssetUUID
 
-        return set(AssetUUID.from_uuid(UUID(a.id)) for a in self._dto.assets)
+            self._asset_uuids_cache = set(
+                AssetUUID.from_uuid(UUID(a.id)) for a in self._dto.assets
+            )
+        return self._asset_uuids_cache
 
     def is_stale(self) -> bool:
         import time

--- a/immich_autotag/albums/album/album_user_wrapper.py
+++ b/immich_autotag/albums/album/album_user_wrapper.py
@@ -11,6 +11,7 @@ from immich_autotag.types.uuid_wrappers import UserUUID
 
 if TYPE_CHECKING:
     from immich_client.models.album_user_response_dto import AlbumUserResponseDto
+    from immich_client.models.album_user_role import AlbumUserRole
 
 
 @attrs.define(auto_attribs=True, slots=True, frozen=True, kw_only=False)
@@ -46,6 +47,10 @@ class AlbumUserWrapper:
             return UserUUID.from_uuid(uid)
         # Ensure we pass a string to from_string to avoid mypy confusion
         return UserUUID.from_string(str(uid))
+
+    @typechecked
+    def get_role(self) -> "AlbumUserRole":
+        return self._user.role
 
     def __str__(self) -> str:
         try:

--- a/immich_autotag/albums/albums/asset_map_manager/manager.py
+++ b/immich_autotag/albums/albums/asset_map_manager/manager.py
@@ -60,50 +60,72 @@ class AssetMapManager:
             level=LogLevel.PROGRESS,
         )
 
+        from immich_client.errors import UnexpectedStatus
+
+        skipped_stale_albums = 0
         for idx, album_wrapper in enumerate(albums, 1):
             # Crazy debug: if the album has the special UUID, raise exception
 
-            if album_wrapper.is_empty():
-                from immich_autotag.logging.levels import LogLevel
-                from immich_autotag.logging.utils import log
+            try:
+                if album_wrapper.is_empty():
+                    from immich_autotag.logging.levels import LogLevel
+                    from immich_autotag.logging.utils import log
 
-                log(
-                    f"Album '{album_wrapper.get_album_name()}' "
-                    f"has no assets after forced reload.",
-                    level=LogLevel.WARNING,
-                )
-                if album_wrapper.get_asset_uuids():
-                    album_url = album_wrapper.get_immich_album_url().geturl()
-                    raise RuntimeError(
-                        f"[DEBUG] Anomalous behavior: Album "
-                        f"'{album_wrapper.get_album_name()}' (URL: {album_url}) "
-                        "had empty asset_ids after initial load, "
-                        "but after a redundant reload it now has assets. "
-                        "This suggests a possible synchronization or lazy loading bug. "
-                        "Please review the album loading logic."
-                    )
-                from immich_autotag.assets.albums.temporary_manager.naming import (
-                    is_temporary_album,
-                )
-
-                if is_temporary_album(album_wrapper.get_album_name()):
                     log(
-                        f"Temporary album '{album_wrapper.get_album_name()}' "
-                        f"marked for removal after map build.",
+                        f"Album '{album_wrapper.get_album_name()}' "
+                        f"has no assets after forced reload.",
                         level=LogLevel.WARNING,
                     )
-            if tracker and tracker.should_log_progress(idx):
-                progress_msg = tracker.get_progress_description(idx)
-                from immich_autotag.logging.levels import LogLevel
-                from immich_autotag.logging.utils import log
+                    if album_wrapper.get_asset_uuids():
+                        album_url = album_wrapper.get_immich_album_url().geturl()
+                        raise RuntimeError(
+                            f"[DEBUG] Anomalous behavior: Album "
+                            f"'{album_wrapper.get_album_name()}' (URL: {album_url}) "
+                            "had empty asset_ids after initial load, "
+                            "but after a redundant reload it now has assets. "
+                            "This suggests a possible synchronization or lazy loading bug. "
+                            "Please review the album loading logic."
+                        )
+                    from immich_autotag.assets.albums.temporary_manager.naming import (
+                        is_temporary_album,
+                    )
 
-                log(
-                    f"[ALBUM-MAP-BUILD][PROGRESS] {progress_msg}. Album "
-                    f"'{album_wrapper.get_album_name()}' reloaded with "
-                    f"{len(album_wrapper.get_asset_uuids())} assets.",
-                    level=LogLevel.PROGRESS,
-                )
-            asset_map.add_album_for_asset_ids(album_wrapper)
+                    if is_temporary_album(album_wrapper.get_album_name()):
+                        log(
+                            f"Temporary album '{album_wrapper.get_album_name()}' "
+                            f"marked for removal after map build.",
+                            level=LogLevel.WARNING,
+                        )
+                if tracker and tracker.should_log_progress(idx):
+                    progress_msg = tracker.get_progress_description(idx)
+                    from immich_autotag.logging.levels import LogLevel
+                    from immich_autotag.logging.utils import log
+
+                    log(
+                        f"[ALBUM-MAP-BUILD][PROGRESS] {progress_msg}. Album "
+                        f"'{album_wrapper.get_album_name()}' reloaded with "
+                        f"{len(album_wrapper.get_asset_uuids())} assets.",
+                        level=LogLevel.PROGRESS,
+                    )
+                asset_map.add_album_for_asset_ids(album_wrapper)
+            except UnexpectedStatus as e:
+                # Album disappeared from Immich between collection load and
+                # this point (e.g. user deleted it, or API returns 400/404 for
+                # stale ids). Skip it and continue building the rest of the map
+                # — otherwise a single stale album aborts the whole build and
+                # forces a full retry on every subsequent asset.
+                if e.status_code in (400, 404):
+                    skipped_stale_albums += 1
+                    log(
+                        f"[ALBUM-MAP-BUILD] Skipping stale album "
+                        f"'{album_wrapper.get_album_name()}' "
+                        f"(uuid={album_wrapper.get_album_uuid()}): "
+                        f"API returned {e.status_code} (likely deleted). "
+                        f"Total skipped so far: {skipped_stale_albums}.",
+                        level=LogLevel.WARNING,
+                    )
+                    continue
+                raise
 
         log(
             "[PROGRESS] [ALBUM-MAP-BUILD] Finished asset-to-albums map construction.",

--- a/immich_autotag/api/immich_proxy/albums/__init__.py
+++ b/immich_autotag/api/immich_proxy/albums/__init__.py
@@ -2,9 +2,11 @@ __all__ = [
     "proxy_create_album",
     "proxy_remove_user_from_album",
     "proxy_search_users",
+    "proxy_update_album_user",
 ]
 from .create_album import proxy_create_album as proxy_create_album
 from .remove_user_from_album import (
     proxy_remove_user_from_album as proxy_remove_user_from_album,
 )
 from .search_users import proxy_search_users as proxy_search_users
+from .update_album_user import proxy_update_album_user as proxy_update_album_user

--- a/immich_autotag/api/immich_proxy/albums/update_album_user.py
+++ b/immich_autotag/api/immich_proxy/albums/update_album_user.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from immich_client.api.albums import update_album_user
+from immich_client.client import AuthenticatedClient
+from immich_client.models.album_user_role import AlbumUserRole
+from immich_client.models.update_album_user_dto import UpdateAlbumUserDto
+from immich_client.types import Response
+
+from immich_autotag.api.immich_proxy.debug import write_operation_debug
+from immich_autotag.types.uuid_wrappers import AlbumUUID, UserUUID
+
+
+def proxy_update_album_user(
+    *,
+    client: AuthenticatedClient,
+    album_id: AlbumUUID,
+    user_id: UserUUID,
+    role: AlbumUserRole,
+) -> Response[Any]:
+    write_operation_debug()
+    body = UpdateAlbumUserDto(role=role)
+    return update_album_user.sync_detailed(
+        client=client, id=album_id.to_uuid(), user_id=str(user_id), body=body
+    )
+
+
+__all__ = ["proxy_update_album_user"]

--- a/immich_autotag/api/logging_proxy/albums/add_assets_to_album.py
+++ b/immich_autotag/api/logging_proxy/albums/add_assets_to_album.py
@@ -281,11 +281,4 @@ def logging_add_assets_to_album(
         asset_wrapper=asset_wrapper, album_wrapper=album_wrapper
     )
 
-    # 5. Consistency Verification
-    _verify_asset_in_album_with_retry(
-        asset_wrapper=asset_wrapper,
-        client=client,
-        album_id=album_wrapper.get_album_uuid(),
-    )
-
     return entry

--- a/immich_autotag/api/logging_proxy/albums/album_permissions.py
+++ b/immich_autotag/api/logging_proxy/albums/album_permissions.py
@@ -4,6 +4,7 @@ Logging proxy for album permission operations.
 This module re-exports permission functions from specialized submodules:
 - albums/add_users_to_album: Functions for adding members to albums
 - albums/remove_user_from_album: Functions for removing members from albums
+- albums/update_album_user_role: Functions for updating a member's role (drift correction)
 
 Design: The ModificationReport is the single source of truth for all logging
 and event tracking. This layer delegates all logging responsibilities to it.
@@ -16,6 +17,9 @@ from immich_autotag.api.logging_proxy.albums.add_users_to_album import (
 from immich_autotag.api.logging_proxy.albums.remove_user_from_album import (
     logging_remove_members_from_album,
 )
+from immich_autotag.api.logging_proxy.albums.update_album_user_role import (
+    logging_update_members_role,
+)
 
 __all__ = [
     # Add members functions
@@ -23,4 +27,6 @@ __all__ = [
     "logging_add_user_to_album",
     # Remove members functions
     "logging_remove_members_from_album",
+    # Update role functions (drift correction)
+    "logging_update_members_role",
 ]

--- a/immich_autotag/api/logging_proxy/albums/update_album_user_role.py
+++ b/immich_autotag/api/logging_proxy/albums/update_album_user_role.py
@@ -1,0 +1,82 @@
+"""
+Logging proxy for updating an album user's role (drift correction).
+
+Used by the sync pipeline when an existing albumUser has a role that differs
+from the role expected by the matching AlbumSelectionRule. Follows the same
+pattern as remove_user_from_album: receives wrapper objects, calls the proxy,
+records the change in ModificationReport.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Sequence
+
+from typeguard import typechecked
+
+from immich_autotag.api.immich_proxy.albums import proxy_update_album_user
+from immich_autotag.context.immich_context import ImmichContext
+from immich_autotag.logging.utils import log_debug
+from immich_autotag.report.modification_kind import ModificationKind
+
+if TYPE_CHECKING:
+    from immich_client.models.album_user_role import AlbumUserRole
+
+    from immich_autotag.albums.album.album_response_wrapper import AlbumResponseWrapper
+    from immich_autotag.users.user_response_wrapper import UserResponseWrapper
+
+
+@typechecked
+def _update_members_role(
+    *,
+    album: "AlbumResponseWrapper",
+    members: Sequence["UserResponseWrapper"],
+    role: "AlbumUserRole",
+    context: ImmichContext,
+) -> None:
+    """
+    [INTERNAL] Update each member's role in the album. No event logging.
+    """
+    album_id = album.get_album_uuid()
+    album_name = album.get_album_name()
+    client = context.get_client_wrapper().get_client()
+    for member in members:
+        user_id = member.get_uuid()
+        proxy_update_album_user(
+            client=client, album_id=album_id, user_id=user_id, role=role
+        )
+        log_debug(
+            f"[ALBUM_PERMISSIONS] Updated role of user {user_id} in {album_name} -> {role.value}"
+        )
+
+
+@typechecked
+def logging_update_members_role(
+    *,
+    album: "AlbumResponseWrapper",
+    members: list["UserResponseWrapper"],
+    role: "AlbumUserRole",
+    context: ImmichContext,
+    matched_rules: Optional[list[str]] = None,
+    groups: Optional[list[str]] = None,
+) -> None:
+    """
+    Update the role of multiple members of an album, with automatic event logging.
+    """
+    _update_members_role(
+        album=album,
+        members=members,
+        role=role,
+        context=context,
+    )
+
+    from immich_autotag.report.modification_report import ModificationReport
+
+    report = ModificationReport.get_instance()
+    report.add_album_permission_modification(
+        kind=ModificationKind.ALBUM_PERMISSION_ROLE_CHANGED,
+        album=album,
+        matched_rules=matched_rules,
+        groups=groups,
+        members=members,
+        access_level=role,
+    )

--- a/immich_autotag/permissions/album_permission_executor/sync_album_permissions.py
+++ b/immich_autotag/permissions/album_permission_executor/sync_album_permissions.py
@@ -1,5 +1,7 @@
 from typeguard import typechecked
 
+from immich_client.models.album_user_role import AlbumUserRole
+
 from immich_autotag.albums.permissions.album_policy_resolver import ResolvedAlbumPolicy
 from immich_autotag.api.logging_proxy.albums.add_users_to_album import (
     logging_add_members_to_album,
@@ -7,10 +9,14 @@ from immich_autotag.api.logging_proxy.albums.add_users_to_album import (
 from immich_autotag.api.logging_proxy.albums.remove_user_from_album import (
     logging_remove_members_from_album,
 )
+from immich_autotag.api.logging_proxy.albums.update_album_user_role import (
+    logging_update_members_role,
+)
 from immich_autotag.context.immich_context import ImmichContext
 from immich_autotag.logging.levels import LogLevel
 from immich_autotag.logging.utils import log, log_debug
 from immich_autotag.types.email_address import EmailAddress
+from immich_autotag.types.uuid_wrappers import UserUUID
 from immich_autotag.users.user_response_wrapper import UserResponseWrapper
 from immich_autotag.users.user_response_wrapper_list import UserResponseWrapperList
 
@@ -28,6 +34,9 @@ class MemberDiff:
         validator=attrs.validators.instance_of(UserResponseWrapperList)
     )
     members_to_remove: UserResponseWrapperList = attrs.field(
+        validator=attrs.validators.instance_of(UserResponseWrapperList)
+    )
+    members_to_update_role: UserResponseWrapperList = attrs.field(
         validator=attrs.validators.instance_of(UserResponseWrapperList)
     )
 
@@ -73,16 +82,50 @@ def _get_current_member_wrappers(
     return wrappers
 
 
+def _get_current_role_map(
+    album_wrapper: "AlbumResponseWrapper",
+) -> dict[UserUUID, AlbumUserRole]:
+    """
+    Return a map user_uuid -> current role for each shared user in the album.
+    Used by drift detection in _calculate_member_diff.
+    """
+    return {
+        album_user.get_uuid(): album_user.get_role()
+        for album_user in album_wrapper.get_album_users()
+    }
+
+
 def _calculate_member_diff(
     target_members: UserResponseWrapperList,
     current_members: UserResponseWrapperList,
+    current_role_map: dict[UserUUID, AlbumUserRole],
+    target_role: AlbumUserRole,
 ) -> MemberDiff:
     target = target_members.deduplicate_by_id()
     current = current_members.deduplicate_by_id()
     members_to_add = target.difference(current).deduplicate_by_id()
     members_to_remove = current.difference(target).deduplicate_by_id()
+
+    # Drift detection: users present in BOTH target and current but with the
+    # wrong role get their role updated. Without this, a one-time mismatch
+    # (e.g. introduced by a manual UI share or a past bug) would persist
+    # across every autotag run because add/remove logic only acts on set
+    # membership, never on role.
+    target_uuids = {m.get_uuid() for m in target}
+    current_uuids = {m.get_uuid() for m in current}
+    in_both = target_uuids & current_uuids
+    drift_list: list[UserResponseWrapper] = [
+        m
+        for m in current
+        if m.get_uuid() in in_both
+        and current_role_map.get(m.get_uuid()) != target_role
+    ]
+    members_to_update_role = UserResponseWrapperList(drift_list).deduplicate_by_id()
+
     return MemberDiff(
-        members_to_add=members_to_add, members_to_remove=members_to_remove
+        members_to_add=members_to_add,
+        members_to_remove=members_to_remove,
+        members_to_update_role=members_to_update_role,
     )
 
 
@@ -90,6 +133,7 @@ def _apply_member_changes(
     album_wrapper: "AlbumResponseWrapper",
     members_to_add: UserResponseWrapperList,
     members_to_remove: UserResponseWrapperList,
+    members_to_update_role: UserResponseWrapperList,
     resolved_policy: ResolvedAlbumPolicy,
     context: ImmichContext,
 ) -> None:
@@ -106,6 +150,15 @@ def _apply_member_changes(
         logging_remove_members_from_album(
             album=album_wrapper,
             members=list(members_to_remove),
+            context=context,
+            matched_rules=resolved_policy.matched_rules,
+            groups=resolved_policy.groups,
+        )
+    if members_to_update_role:
+        logging_update_members_role(
+            album=album_wrapper,
+            members=list(members_to_update_role),
+            role=resolved_policy.access_level,
             context=context,
             matched_rules=resolved_policy.matched_rules,
             groups=resolved_policy.groups,
@@ -155,21 +208,32 @@ def sync_album_permissions(
     ), "current_member_wrappers contains non-UserResponseWrapper"
     from immich_autotag.users.user_response_wrapper_list import UserResponseWrapperList
 
+    current_role_map = _get_current_role_map(album_wrapper)
     member_diff: MemberDiff = _calculate_member_diff(
         UserResponseWrapperList(target_members),
         UserResponseWrapperList(current_member_wrappers),
+        current_role_map=current_role_map,
+        target_role=resolved_policy.access_level,
     )
     _apply_member_changes(
         album_wrapper,
         member_diff.members_to_add,
         member_diff.members_to_remove,
+        member_diff.members_to_update_role,
         resolved_policy,
         context,
     )
-    if member_diff.members_to_add or member_diff.members_to_remove:
+    any_change = (
+        member_diff.members_to_add
+        or member_diff.members_to_remove
+        or member_diff.members_to_update_role
+    )
+    if any_change:
         log(
             f"[ALBUM_PERMISSIONS] Synced {album_name}: "
-            f"+{len(member_diff.members_to_add)} PONER, -{len(member_diff.members_to_remove)} QUITAR",
+            f"+{len(member_diff.members_to_add)} PONER, "
+            f"-{len(member_diff.members_to_remove)} QUITAR, "
+            f"~{len(member_diff.members_to_update_role)} ROL",
             level=LogLevel.FOCUS,
         )
     else:

--- a/immich_autotag/permissions/album_permission_executor/sync_album_permissions.py
+++ b/immich_autotag/permissions/album_permission_executor/sync_album_permissions.py
@@ -93,13 +93,11 @@ def _apply_member_changes(
     resolved_policy: ResolvedAlbumPolicy,
     context: ImmichContext,
 ) -> None:
-    from immich_autotag.api.logging_proxy.types import AlbumUserRole
-
     if members_to_add:
         logging_add_members_to_album(
             album=album_wrapper,
             members=list(members_to_add),
-            access_level=AlbumUserRole.EDITOR,
+            access_level=resolved_policy.access_level,
             context=context,
             matched_rules=resolved_policy.matched_rules,
             groups=resolved_policy.groups,

--- a/immich_autotag/permissions/album_permission_executor/sync_album_permissions.py
+++ b/immich_autotag/permissions/album_permission_executor/sync_album_permissions.py
@@ -1,6 +1,5 @@
-from typeguard import typechecked
-
 from immich_client.models.album_user_role import AlbumUserRole
+from typeguard import typechecked
 
 from immich_autotag.albums.permissions.album_policy_resolver import ResolvedAlbumPolicy
 from immich_autotag.api.logging_proxy.albums.add_users_to_album import (
@@ -117,8 +116,7 @@ def _calculate_member_diff(
     drift_list: list[UserResponseWrapper] = [
         m
         for m in current
-        if m.get_uuid() in in_both
-        and current_role_map.get(m.get_uuid()) != target_role
+        if m.get_uuid() in in_both and current_role_map.get(m.get_uuid()) != target_role
     ]
     members_to_update_role = UserResponseWrapperList(drift_list).deduplicate_by_id()
 

--- a/immich_autotag/report/modification_kind.py
+++ b/immich_autotag/report/modification_kind.py
@@ -263,6 +263,13 @@ class ModificationKind(Enum):
         requires_album=True,
         requires_tag=False,
     )
+    ALBUM_PERMISSION_ROLE_CHANGED = ModificationKindInfo(
+        name="ALBUM_PERMISSION_ROLE_CHANGED",
+        level=ModificationLevel.MODIFICATION,
+        requires_asset=False,
+        requires_album=True,
+        requires_tag=False,
+    )
     ALBUM_PERMISSION_SHARE_FAILED = ModificationKindInfo(
         name="ALBUM_PERMISSION_SHARE_FAILED",
         level=ModificationLevel.ERROR,

--- a/immich_autotag/report/modification_report.py
+++ b/immich_autotag/report/modification_report.py
@@ -406,6 +406,7 @@ class ModificationReport:
             ModificationKind.ALBUM_PERMISSION_NO_MATCH,
             ModificationKind.ALBUM_PERMISSION_SHARED,
             ModificationKind.ALBUM_PERMISSION_REMOVED,
+            ModificationKind.ALBUM_PERMISSION_ROLE_CHANGED,
             ModificationKind.ALBUM_PERMISSION_SHARE_FAILED,
         }
         if extra is None:

--- a/immich_autotag/statistics/_find_max_skip_n_recent.py
+++ b/immich_autotag/statistics/_find_max_skip_n_recent.py
@@ -9,7 +9,7 @@ from immich_autotag.statistics.run_statistics import RunStatistics
 
 @typechecked
 def get_max_skip_n_from_recent(
-    logs_dir: Optional[Path] = None, max_age_hours: int = 24, overlap: int = 100
+    logs_dir: Optional[Path] = None, max_age_hours: int = 72, overlap: int = 100
 ) -> Optional[int]:
     """
     Searches all run_statistics.yaml from the last max_age_hours hours and returns the maximum count minus overlap.

--- a/immich_autotag/statistics/_find_max_skip_n_recent.py
+++ b/immich_autotag/statistics/_find_max_skip_n_recent.py
@@ -9,7 +9,7 @@ from immich_autotag.statistics.run_statistics import RunStatistics
 
 @typechecked
 def get_max_skip_n_from_recent(
-    logs_dir: Optional[Path] = None, max_age_hours: int = 3, overlap: int = 100
+    logs_dir: Optional[Path] = None, max_age_hours: int = 24, overlap: int = 100
 ) -> Optional[int]:
     """
     Searches all run_statistics.yaml from the last max_age_hours hours and returns the maximum count minus overlap.

--- a/immich_autotag/statistics/checkpoint_manager.py
+++ b/immich_autotag/statistics/checkpoint_manager.py
@@ -41,7 +41,7 @@ class CheckpointManager:
         origen = None
         if enable_checkpoint_resume and config_resume_previous:
             max_skip_n = get_max_skip_n_from_recent(
-                max_age_hours=3, overlap=self.OVERLAP
+                max_age_hours=24, overlap=self.OVERLAP
             )
             if max_skip_n is not None and max_skip_n > 0:
                 skip_n = max_skip_n

--- a/immich_autotag/statistics/checkpoint_manager.py
+++ b/immich_autotag/statistics/checkpoint_manager.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import attr
@@ -67,3 +68,89 @@ class CheckpointManager:
             level=LogLevel.PROGRESS,
         )
         return skip_n
+
+    @typechecked
+    def maybe_archive_completed_cycle(self, total_assets: int) -> bool:
+        """
+        Detect whether the previous pass already covered the whole library
+        and, if so, archive its run dirs out of `logs_local/` so the next
+        skip_n calculation falls back to config (typically 0) and a fresh
+        cycle starts.
+
+        Without this, the max-recent-count logic in
+        `get_max_skip_n_from_recent` keeps resuming near the library end
+        forever once a pass has reached the final assets — every new build
+        sees the high count YAML and resumes one overlap before it.
+
+        Detection: any recent run YAML with count >= total_assets - OVERLAP
+        is considered an end-of-cycle marker.
+
+        Side effect: when triggered, all current recent run dirs are moved
+        to `<logs_local>/_archive/cycle-<YYYYmmdd_HHMMSS>/`. Callers should
+        recompute skip_n after this returns True (the existing
+        `StatisticsManager._set_skip_n` does the right thing once the
+        directory is empty of recent dirs).
+
+        Returns True if archiving happened, False otherwise.
+        """
+        from immich_autotag.run_output.manager import RunOutputManager
+        from immich_autotag.statistics.run_statistics import RunStatistics
+
+        threshold = total_assets - self.OVERLAP
+        recent_dirs = list(
+            RunOutputManager.current().find_recent_run_dirs(max_age_hours=72)
+        )
+
+        cycle_completed = False
+        for run_exec in recent_dirs:
+            stats_path = run_exec.get_run_statistics_path()
+            if not stats_path.exists():
+                continue
+            try:
+                stats = RunStatistics.from_yaml(stats_path)
+                if stats.count >= threshold:
+                    cycle_completed = True
+                    break
+            except Exception as e:
+                log(
+                    f"[CHECKPOINT] Could not read {stats_path} during cycle "
+                    f"detection: {e}",
+                    level=LogLevel.WARNING,
+                )
+                continue
+
+        if not cycle_completed:
+            return False
+
+        if not recent_dirs:
+            # Should not happen given cycle_completed=True implies at least one
+            # readable YAML, but be defensive.
+            return False
+
+        # Use the parent of any recent run dir as the logs_local root
+        logs_dir = recent_dirs[0].path.parent
+        archive_root = (
+            logs_dir / "_archive" / f"cycle-{datetime.now():%Y%m%d_%H%M%S}"
+        )
+        archive_root.mkdir(parents=True, exist_ok=True)
+
+        archived = 0
+        for run_exec in recent_dirs:
+            try:
+                run_exec.path.rename(archive_root / run_exec.path.name)
+                archived += 1
+            except Exception as e:
+                log(
+                    f"[CHECKPOINT] Failed to archive {run_exec.path}: {e}",
+                    level=LogLevel.WARNING,
+                )
+
+        log(
+            f"[CHECKPOINT] End of cycle detected: a recent run reached "
+            f"count >= {threshold} (= total_assets {total_assets} - "
+            f"OVERLAP {self.OVERLAP}). Archived {archived} run dir(s) to "
+            f"{archive_root}. Next skip_n will fall back to config "
+            f"(typically 0), starting a fresh pass.",
+            level=LogLevel.PROGRESS,
+        )
+        return True

--- a/immich_autotag/statistics/checkpoint_manager.py
+++ b/immich_autotag/statistics/checkpoint_manager.py
@@ -41,7 +41,7 @@ class CheckpointManager:
         origen = None
         if enable_checkpoint_resume and config_resume_previous:
             max_skip_n = get_max_skip_n_from_recent(
-                max_age_hours=24, overlap=self.OVERLAP
+                max_age_hours=72, overlap=self.OVERLAP
             )
             if max_skip_n is not None and max_skip_n > 0:
                 skip_n = max_skip_n

--- a/immich_autotag/statistics/checkpoint_manager.py
+++ b/immich_autotag/statistics/checkpoint_manager.py
@@ -129,9 +129,7 @@ class CheckpointManager:
 
         # Use the parent of any recent run dir as the logs_local root
         logs_dir = recent_dirs[0].path.parent
-        archive_root = (
-            logs_dir / "_archive" / f"cycle-{datetime.now():%Y%m%d_%H%M%S}"
-        )
+        archive_root = logs_dir / "_archive" / f"cycle-{datetime.now():%Y%m%d_%H%M%S}"
         archive_root.mkdir(parents=True, exist_ok=True)
 
         archived = 0

--- a/immich_autotag/statistics/checkpoint_manager.py
+++ b/immich_autotag/statistics/checkpoint_manager.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 @attr.s(auto_attribs=True, kw_only=True, slots=True)
 class CheckpointManager:
     stats_manager: "StatisticsManager" = attr.ib(init=True)
-    OVERLAP: int = attr.ib(default=100, init=False)
+    OVERLAP: int = attr.ib(default=500, init=False)
 
     @stats_manager.validator
     def _validate_stats_manager(self, attribute, value):

--- a/immich_autotag/statistics/statistics_manager.py
+++ b/immich_autotag/statistics/statistics_manager.py
@@ -369,6 +369,17 @@ class StatisticsManager:
         self.get_or_create_run_stats().total_assets = total_assets
         self.set_total_assets(total_assets)
 
+        # Cycle wrap-around: if a recent run already covered the whole
+        # library, archive its YAMLs and reset skip_n so this run starts a
+        # fresh pass from the beginning. The check has to happen here
+        # (rather than in __attrs_post_init__) because total_assets is only
+        # known after fetch_total_assets returns, just before this method
+        # is called. The pre-existing _set_skip_n() call from construction
+        # used the old high count; we recompute now that the workspace has
+        # been cleared.
+        if self._checkpoint.maybe_archive_completed_cycle(total_assets):
+            self._set_skip_n()
+
     def get_max_assets(self) -> int | None:
         """
         Returns the updated value of max_assets, applying refresh logic if necessary.

--- a/immich_autotag/version.py
+++ b/immich_autotag/version.py
@@ -1,4 +1,4 @@
 # This file is automatically updated in the build/distribution process
 __version__ = "0.81.0"
-__git_commit__ = "7f34aa27"
-__git_describe__ = "v0.80.10-22-g7f34aa27-dirty"
+__git_commit__ = "a143f93f"
+__git_describe__ = "v0.81.0-0-ga143f93f-dirty"

--- a/immich_autotag/version.py
+++ b/immich_autotag/version.py
@@ -1,4 +1,4 @@
 # This file is automatically updated in the build/distribution process
-__version__ = "0.80.10"
-__git_commit__ = "bb26fd28"
-__git_describe__ = "v0.80.10-0-gbb26fd28-dirty"
+__version__ = "0.81.0"
+__git_commit__ = "7f34aa27"
+__git_describe__ = "v0.80.10-22-g7f34aa27-dirty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "immich-autotag"
-version = "0.80.10"
+version = "0.81.0"
 description = "Immich autotagging and album management system"
 authors = [
 	{ name = "txemi", email = "txemitron@gmail.com" }


### PR DESCRIPTION
## Summary

Releases v0.81.0 (already published to PyPI + Docker Hub on 2026-05-21).
Brings the batch-processing branch up to main after ~3 weeks of accumulated
fixes, features and operational improvements.

### New features
- **Album permission role drift detection** (6745ba3f, 87e20337): the
  permission sync now also re-evaluates the role of users present in
  both target and current sets, so `view` vs `editor` drift is
  self-healing. Complements the hardcoded-EDITOR fix in f29bb031.

### CI / operational
- **Auto-chain in Jenkinsfile** (d4ae7b6e): `post.success` re-queues
  the same job so the batch-processing pipeline is self-perpetuating.
  Failure stops the chain by design.
- **Wrap-around at end of library** (597ed8cf) plus OVERLAP=500
  (167f2b2a) so the threshold is actually reachable. This is what
  closes a cycle cleanly and restarts from skip=0.
- **archiveArtifacts** narrowed to current build run dirs only and
  fingerprinting disabled (ed4084dc) to avoid multi-hour post-actions.
- Build discard window raised, no more pinning of successful builds
  (6d8e686b) so old builds rotate normally.

### Performance (albums)
- Cache asset_uuids on AlbumDtoState (e83ae46e).
- _build_map resilient to stale albums (404/400) (9f15e36a).
- Drop post-add consistency verify, huge slowdown for big albums
  (80a55322).

### Bug fixes
- Respect AlbumSelectionRule.access (was hardcoded EDITOR) (f29bb031).
- Drop local AssetUUID import that shadowed module-level binding
  (a89aecdb).
- Max age window for checkpoint resume (ebd6969f, 2ee7568d).

### Docs
- CLAUDE.md updates: explicit maintainer rules (git auth, auto-mode
  override, scope), English examples (f7b37a1a, 658219cd), active-focus
  switch to ops/batch-processing (0002601d).

## Test plan

- [x] Quality Gate STANDARD passes (15/15 checks) on the merge head.
- [x] Jenkins chain on ops/batch-processing has been running
      continuously since 2026-05-17 with all SUCCESS builds (>10
      sequential builds completed).
- [x] Cycle 3 closed cleanly: wrap-around fired at #277 (100.1% of
      library), cycle 4 immediately restarted at skip=0.
- [x] Cycle 4 in progress (~80% covered as of 2026-05-20).
- [x] Auto-chain confirmed firing on every successful build since
      d4ae7b6e: chain self-perpetuates without external dispatch.
- [x] Jenkins tags pushed to GitHub from build #285 onwards (GitHub
      App permission widened on 2026-05-20).
- [x] PyPI package `immich-autotag 0.81.0` published OK.
- [x] Docker images published: `txemi/immich-autotag:latest`,
      `:0.81.0`, `:cron`.

## Branch preservation

`ops/batch-processing` is **kept alive** after this merge: it is the
permanent runner of the Jenkins batch-processing chain. Future
development happens on this branch; main reflects what has been
released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)