### PR TITLE
ci: darnlink docs-link gate + robustify internal Markdown links

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -1,0 +1,26 @@
+name: Docs link gate
+
+# Read-only darnlink gate for the docs' uuid-anchored Markdown links.
+# Independent of the (currently disabled) test CI: it needs no Immich client
+# library, only uv + the darnlink CLI, so it can run on every push/PR.
+on:
+  push:
+    paths:
+      - '**/*.md'
+      - 'scripts/devtools/darnlink_docs_gate.sh'
+      - '.github/workflows/docs-links.yml'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - 'scripts/devtools/darnlink_docs_gate.sh'
+      - '.github/workflows/docs-links.yml'
+
+jobs:
+  darnlink:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: darnlink docs-link gate
+        run: bash scripts/devtools/darnlink_docs_gate.sh .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,14 @@ repos:
     hooks:
       # darnlink docs-link gate: fails the commit if any uuid-anchored Markdown
       # link needs repair (e.g. a doc was moved but a link still points at the
-      # old path). Read-only. To fix:  darnlink . --write
+      # old path). Read-only. To fix:
+      #   uvx --from "git+https://github.com/txemi/darnlink@v0.1.1" darnlink . --write
       - id: darnlink-docs-links
         name: darnlink docs-link gate
-        entry: scripts/devtools/darnlink_docs_gate.sh
-        language: script
+        # invoked via `bash` (not relying on the file's executable bit), matching
+        # how devtools scripts are run elsewhere in the repo.
+        entry: bash scripts/devtools/darnlink_docs_gate.sh
+        language: system
         # darnlink builds a repo-wide uuid index, so run once over the tree
         # (not per staged file) whenever any Markdown file changes.
         files: \.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# pre-commit hooks for immich-autotag.
+# Install once:  pipx install pre-commit && pre-commit install
+# See https://pre-commit.com
+repos:
+  - repo: local
+    hooks:
+      # darnlink docs-link gate: fails the commit if any uuid-anchored Markdown
+      # link needs repair (e.g. a doc was moved but a link still points at the
+      # old path). Read-only. To fix:  darnlink . --write
+      - id: darnlink-docs-links
+        name: darnlink docs-link gate
+        entry: scripts/devtools/darnlink_docs_gate.sh
+        language: script
+        # darnlink builds a repo-wide uuid index, so run once over the tree
+        # (not per staged file) whenever any Markdown file changes.
+        files: \.md$
+        pass_filenames: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,6 +108,21 @@ pipeline {
                 }
             }
         }
+        stage('Quality Gate (Docs Links)') {
+            steps {
+                script {
+                    echo "================ DOCS LINK GATE (darnlink) ================"
+                    echo "[DOCS LINK GATE] Checking uuid-anchored Markdown links (read-only, no --write)"
+                    sh '''
+                        git config --global --add safe.directory "$PWD"
+                        # darnlink runs via uvx; ensure uv is available on the agent
+                        command -v uvx >/dev/null 2>&1 || pip install --quiet uv
+                        chmod +x scripts/devtools/darnlink_docs_gate.sh
+                        bash scripts/devtools/darnlink_docs_gate.sh .
+                    '''
+                }
+            }
+        }
         stage('Quality Gate (Shell Script)') {
             when {
                 expression { false } // Disabled: deprecated shell quality gate. Keep stage for history, skip execution.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,9 +115,10 @@ pipeline {
                     echo "[DOCS LINK GATE] Checking uuid-anchored Markdown links (read-only, no --write)"
                     sh '''
                         git config --global --add safe.directory "$PWD"
-                        # darnlink runs via uvx; ensure uv is available on the agent
-                        command -v uvx >/dev/null 2>&1 || pip install --quiet uv
-                        chmod +x scripts/devtools/darnlink_docs_gate.sh
+                        # darnlink runs via uvx; ensure uv is available in a
+                        # predictable location (user site, not a global pip).
+                        export PATH="$HOME/.local/bin:$PATH"
+                        command -v uvx >/dev/null 2>&1 || python3 -m pip install --quiet --user uv
                         bash scripts/devtools/darnlink_docs_gate.sh .
                     '''
                 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+---
+uuid: 0fe0abb8-5ac1-4868-8e99-4210639a02fc
+---
+
 # 1. Contributing to Immich AutoTag
 
 Thank you for your interest in contributing to Immich AutoTag! This project is developed in spare time and all contributions are welcome.
@@ -84,7 +88,7 @@ Once these are in place, they will be enforced before any merge to `main`. **Unt
 - **Always target `develop` branch with your PRs, not `main`** (except for critical hotfixes, which require discussion first)
 
 ## 1.5. Getting Started
-- See the [Developer Guide](./development.md) for technical details and project structure.
+- See the [Developer Guide](./development.md) <!-- uuid: 2adee19a-d0f2-4d34-9d64-ab1da0a9f2b6 --> for technical details and project structure.
 - If you have questions, open an issue or start a discussion on GitHub.
 
 ## 1.6. Publishing

--- a/docs/dev/branches.md
+++ b/docs/dev/branches.md
@@ -54,16 +54,16 @@ This document outlines the branching strategy used in immich-autotag, particular
 
 ## Related Documentation
 
-- **Versioning & Release Workflow:** See [versioning_workflow.md](./versioning_workflow.md)
+- **Versioning & Release Workflow:** See [versioning_workflow.md](./versioning_workflow.md) <!-- uuid: 351461cb-9f8e-46f4-acdd-545ec2f92e20 -->
   - How versions are tagged
   - When to create tags
   - How develop relates to version management
 
-- **Contributing Guidelines:** See [../CONTRIBUTING.md](../CONTRIBUTING.md)
+- **Contributing Guidelines:** See [../CONTRIBUTING.md](../CONTRIBUTING.md) <!-- uuid: 0fe0abb8-5ac1-4868-8e99-4210639a02fc -->
   - General contribution process
   - PR requirements
 
-- **Git Hygiene Practices:** See [../development.md](../development.md)
+- **Git Hygiene Practices:** See [../development.md](../development.md) <!-- uuid: 2adee19a-d0f2-4d34-9d64-ab1da0a9f2b6 -->
   - Commit message conventions
   - When to squash vs. merge
 

--- a/docs/dev/versioning_workflow.md
+++ b/docs/dev/versioning_workflow.md
@@ -1,3 +1,7 @@
+---
+uuid: 351461cb-9f8e-46f4-acdd-545ec2f92e20
+---
+
 # Versioning and Release Workflow for immich-autotag
 
 ## Versioning conventions (SemVer + Quality Gate)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,7 @@
+---
+uuid: 2adee19a-d0f2-4d34-9d64-ab1da0a9f2b6
+---
+
 # 1. Developer Guide: Immich Autotag
 
 

--- a/docs/functional_blocks_matrix.md
+++ b/docs/functional_blocks_matrix.md
@@ -27,5 +27,5 @@ This table lists the main functional blocks (features) of Immich AutoTag, their 
 - This table maps functional blocks to active issues in the v2.0 issue system (issues 0020+).
 - Legacy issues (0001-0019) have been archived and consolidated into the current thematic organization.
 - Issue links use the naming convention `NNNN-descriptive-slug` for consistency with the registry.
-- See [Issue Registry](./issues/registry.md) for the complete list of active and legacy issues.
+- See [Issue Registry](./issues/registry.md) <!-- uuid: 805cc158-bb61-497d-96dd-7a6efece6acf --> for the complete list of active and legacy issues.
 - Status indicates current implementation progress; "In progress" may include completed features with ongoing refinement.

--- a/docs/issues/0031-cicd/subtasks/0014-quality-gate/subtasks/003-darnlink-docs-link-gate/README.md
+++ b/docs/issues/0031-cicd/subtasks/0014-quality-gate/subtasks/003-darnlink-docs-link-gate/README.md
@@ -1,0 +1,55 @@
+# 003 · darnlink docs-link gate
+
+A read-only quality gate that keeps the documentation's internal Markdown links
+from silently breaking when files move.
+
+## Problem
+
+The docs tree is large and gets reorganized. When a `.md` file is moved or
+renamed, relative links pointing at it go stale and nobody notices until a
+reader hits a 404. This has already required manual cleanup (see
+`../../0015-github-actions-pypi-publishing/subtasks/003-clean-up/manual_cleanup_links.md`).
+
+## What darnlink does
+
+[darnlink](https://github.com/txemi/darnlink) anchors each internal Markdown
+link to the target file's `uuid` (added to the target's frontmatter, plus an
+inline `<!-- uuid: ... -->` comment next to the link). The link stays a normal,
+clickable Markdown link. When a file moves, the path is stale but the uuid still
+resolves, so darnlink can repair the path deterministically — no database, no
+editor lock-in. It is **not** a broken-link checker: it maintains the
+*move-resilience* of links it has anchored.
+
+## What was done
+
+1. **Robustify (one-off):** `darnlink docs/ --robustify --create-frontmatter --write`
+   anchored the existing internal links under `docs/` (small footprint — a
+   handful of files gained a `uuid` and their links an anchor). Scope is `docs/`
+   only, so the repo-root `README.md` (rendered on the GitHub landing page) is
+   left untouched.
+2. **Gate (ongoing):** `scripts/devtools/darnlink_docs_gate.sh` runs darnlink in
+   its default *report* mode (no `--write`) over the repo. It exits non-zero if
+   any anchored link needs repair, is unresolved, or a target has invalid
+   frontmatter. The darnlink version is pinned (`v0.1.1`).
+
+## Where it runs (one script, three gates)
+
+| Gate | Wiring |
+|------|--------|
+| pre-commit | `.pre-commit-config.yaml` → hook `darnlink-docs-links` |
+| Jenkins | `Jenkinsfile` stage `Quality Gate (Docs Links)` |
+| GitHub Actions | `.github/workflows/docs-links.yml` (independent of the disabled test CI — needs no Immich client lib) |
+
+## Fixing a failure
+
+If the gate is red, a doc moved and a link is stale. Repair and commit:
+
+```bash
+uvx --from "git+https://github.com/txemi/darnlink@v0.1.1" darnlink . --write
+```
+
+## Status
+
+- [x] Robustify `docs/` (one-off).
+- [x] Shared gate script + wired into pre-commit, Jenkins, GitHub Actions.
+- [ ] Verify the three gates run green in CI after merge.

--- a/docs/issues/0032-user-management-and-access-control-feature/subtasks/0018-access-control-policies/README.md
+++ b/docs/issues/0032-user-management-and-access-control-feature/subtasks/0018-access-control-policies/README.md
@@ -48,8 +48,8 @@ Immich does not provide native user groups, but we need to assign album access a
 - **Well-reported**: Detailed logging in modification_report for audit trail
 
 ## Design Documents
-- [Operational Specification](design/OPERATIONAL_SPEC.md) - **START HERE**: User requirements and implementation details
-- [Technical Design](design/technical_design.md) - Lower-level implementation patterns
+- [Operational Specification](design/OPERATIONAL_SPEC.md) <!-- uuid: 89aa0c6b-8243-41af-acfd-a5d9d79c3e06 --> - **START HERE**: User requirements and implementation details
+- [Technical Design](design/technical_design.md) <!-- uuid: 00aef780-c8c6-49ee-b4d3-2020470eb433 --> - Lower-level implementation patterns
 
 ## Definition of Done (DoD)
 - Config supports `user_groups` and `album_selection_rules` blocks

--- a/docs/issues/0032-user-management-and-access-control-feature/subtasks/0018-access-control-policies/design/OPERATIONAL_SPEC.md
+++ b/docs/issues/0032-user-management-and-access-control-feature/subtasks/0018-access-control-policies/design/OPERATIONAL_SPEC.md
@@ -1,3 +1,7 @@
+---
+uuid: 89aa0c6b-8243-41af-acfd-a5d9d79c3e06
+---
+
 # Operational Specification - Album Permission Groups (0018)
 
 **Author**: txemi  

--- a/docs/issues/0032-user-management-and-access-control-feature/subtasks/0018-access-control-policies/design/technical_design.md
+++ b/docs/issues/0032-user-management-and-access-control-feature/subtasks/0018-access-control-policies/design/technical_design.md
@@ -1,3 +1,7 @@
+---
+uuid: 00aef780-c8c6-49ee-b4d3-2020470eb433
+---
+
 # Technical Design - 0018 User Groups and Album Policies
 
 ## Overview

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -45,7 +45,7 @@ Each issue resides in its own numbered folder (`00XX-slug`):
 
 ## Registry
 
-See [`registry.md`](./registry.md) for a complete list of active issues with status and version information.
+See [`registry.md`](./registry.md) <!-- uuid: 805cc158-bb61-497d-96dd-7a6efece6acf --> for a complete list of active issues with status and version information.
 
 ---
 

--- a/docs/issues/registry.md
+++ b/docs/issues/registry.md
@@ -1,3 +1,7 @@
+---
+uuid: 805cc158-bb61-497d-96dd-7a6efece6acf
+---
+
 # Issue Registry
 
 Current active issues (v2.0 system with thematic organization):

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# darnlink docs-link gate
+# ------------------------
+# Read-only quality gate for the documentation's Markdown links.
+#
+# darnlink anchors each internal Markdown link to the target file's `uuid`
+# (frontmatter + an inline `<!-- uuid: ... -->` comment). When a file moves,
+# the path in the link goes stale but the uuid still points at the target.
+# This gate runs darnlink in its default *report* mode (NO --write): it exits
+# non-zero if any anchored link needs repair, has an unresolved uuid, or a
+# target has invalid frontmatter. To fix locally:
+#
+#     uvx --from "git+https://github.com/txemi/darnlink@v0.1.1" darnlink . --write
+#
+# Shared by the three gates so the logic lives in one place:
+#   - pre-commit  (.pre-commit-config.yaml)
+#   - Jenkins     (Jenkinsfile stage 'Quality Gate (Docs Links)')
+#   - GitHub Actions (.github/workflows/docs-links.yml)
+#
+# Env overrides:
+#   DARNLINK_REF   git tag/branch of darnlink to use   (default: v0.1.1)
+#   DARNLINK_FROM  full uvx --from spec (path or git+)  (default: the pinned tag)
+#                  e.g. DARNLINK_FROM=/path/to/local/darnlink for local dev
+#
+# Args:
+#   $1  scan root (default: repo root '.') — darnlink needs the whole tree to
+#       build the uuid index, so scan the repo root, not a single file.
+set -euo pipefail
+
+DARNLINK_REF="${DARNLINK_REF:-v0.1.1}"
+DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK_REF}}"
+SCAN_ROOT="${1:-.}"
+
+echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (read-only)"
+exec uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}"

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -19,8 +19,8 @@
 #   - GitHub Actions (.github/workflows/docs-links.yml)
 #
 # Env overrides:
-#   DARNLINK_REF   git tag/branch of darnlink to use   (default: v0.1.1)
-#   DARNLINK_FROM  full uvx --from spec (path or git+)  (default: the pinned tag)
+#   DARNLINK_REF   git ref of darnlink to use   (default: immutable SHA of v0.1.1)
+#   DARNLINK_FROM  full uvx --from spec (path or git+)  (default: the pinned SHA)
 #                  e.g. DARNLINK_FROM=/path/to/local/darnlink for local dev
 #
 # Args:
@@ -28,7 +28,10 @@
 #       build the uuid index, so scan the repo root, not a single file.
 set -euo pipefail
 
-DARNLINK_REF="${DARNLINK_REF:-v0.1.1}"
+# Pinned to an immutable commit SHA (== tag v0.1.1). Tags can be force-moved,
+# which would weaken CI reproducibility / supply-chain integrity, so we pin the
+# SHA and keep the tag only as a human-readable note.
+DARNLINK_REF="${DARNLINK_REF:-5929bb50590a86970a011d15e2f19a7e26e5a7c9}"  # v0.1.1
 DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK_REF}}"
 SCAN_ROOT="${1:-.}"
 


### PR DESCRIPTION
## What

Adopts [darnlink](https://github.com/txemi/darnlink) to keep the docs' internal Markdown links from silently breaking on file moves, and wires it as a **read-only quality gate** into the three CI paths.

### 1. Robustify (one-off) — commit `docs:`
`darnlink docs/ --robustify --create-frontmatter --write` anchored the existing internal links under `docs/` to their target `uuid`. Small footprint (10 files). **Scope is `docs/` only** — repo-root `README.md` (GitHub landing page) is deliberately untouched.

### 2. Gate (ongoing) — commit `ci:`
One shared script `scripts/devtools/darnlink_docs_gate.sh` (darnlink in report mode, no `--write`, pinned `v0.1.1`) wired into:

| Gate | Wiring |
|------|--------|
| pre-commit | `.pre-commit-config.yaml` |
| Jenkins | `Jenkinsfile` → stage `Quality Gate (Docs Links)` |
| GitHub Actions | `.github/workflows/docs-links.yml` |

The Actions workflow is **independent of the disabled test CI** — it needs no Immich client library, only `uv` + darnlink, so it runs on every push/PR touching `.md`.

## Why

Doc reorganizations have already required manual link cleanup. darnlink makes anchored links survive moves (it repairs the path by uuid). It is **not** a broken-link checker — it maintains move-resilience of anchored links.

## Notes
- darnlink is **not** a broken-link validator; that's a separate concern (lychee/markdown-link-check) not in scope here.
- Documented under `docs/issues/0031-cicd/subtasks/0014-quality-gate/subtasks/003-darnlink-docs-link-gate/`.
- The `docs-links` Actions workflow should self-validate green on this PR.

## Fixing a red gate
```bash
uvx --from "git+https://github.com/txemi/darnlink@v0.1.1" darnlink . --write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)