### PR TITLE
docs(links): robustify 5 links + darnlink gate v0.5.0 (repair→check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-All versions follow [Semantic Versioning](https://semver.org/). For details on how version digits are used and the meaning of Quality Gate points, see [`docs/dev/versioning_workflow.md`](docs/dev/versioning_workflow.md).
+All versions follow [Semantic Versioning](https://semver.org/). For details on how version digits are used and the meaning of Quality Gate points, see [`docs/dev/versioning_workflow.md`](docs/dev/versioning_workflow.md) <!-- uuid: 351461cb-9f8e-46f4-acdd-545ec2f92e20 -->.
 
 
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can run Immich AutoTag using any of the following methods:
 That's it! Your Immich autotagging tool is ready to use.
 
 > **Do you prefer to download the code and run it manually?**
-> See the section [Installation and Automatic Client Generation](./docs/development.md#15-installation-and-automatic-client-generation) in the [Development Guide](./docs/development.md).
+> See the section [Installation and Automatic Client Generation](./docs/development.md#15-installation-and-automatic-client-generation) <!-- uuid: 2adee19a-d0f2-4d34-9d64-ab1da0a9f2b6 --> in the [Development Guide](./docs/development.md) <!-- uuid: 2adee19a-d0f2-4d34-9d64-ab1da0a9f2b6 -->.
 
 
 ## 1.5. Reviewing Results: Example Links
@@ -262,9 +262,9 @@ You can define also special tags or albums for photos that do not belong to any 
 
 ## 1.7. Development
 
-For information about project structure, contributing, and technical details, see the [Developer Guide](./docs/development.md).
+For information about project structure, contributing, and technical details, see the [Developer Guide](./docs/development.md) <!-- uuid: 2adee19a-d0f2-4d34-9d64-ab1da0a9f2b6 -->.
 
-If you would like to contribute, please see the new [Contributing Guide](./docs/CONTRIBUTING.md). Any help is welcome—especially with re-enabling GitHub Actions (CI/CD), which is currently disabled due to the challenge of embedding the Immich client library in the build process. This project is developed in spare time, so all contributions are greatly appreciated!
+If you would like to contribute, please see the new [Contributing Guide](./docs/CONTRIBUTING.md) <!-- uuid: 0fe0abb8-5ac1-4868-8e99-4210639a02fc -->. Any help is welcome—especially with re-enabling GitHub Actions (CI/CD), which is currently disabled due to the challenge of embedding the Immich client library in the build process. This project is developed in spare time, so all contributions are greatly appreciated!
 
 ## 1.8. Support
 For questions, issues, or feature requests, please use the [GitHub Issues](https://github.com/txemi/immich-autotag/issues) ticketing system.

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -7,11 +7,12 @@
 # darnlink anchors each internal Markdown link to the target file's `uuid`
 # (frontmatter + an inline `<!-- uuid: ... -->` comment). When a file moves,
 # the path in the link goes stale but the uuid still points at the target.
-# This gate runs darnlink in its default *report* mode (NO --write): it exits
-# non-zero if any anchored link needs repair, has an unresolved uuid, or a
-# target has invalid frontmatter. To fix locally:
+# This gate runs `darnlink check` (report-only, NO --write): BOTH axes in one
+# pass — integrity (broken/unresolvable anchored links + invalid frontmatter)
+# AND strict (a plain link whose target has a uuid, left un-anchored). Exit
+# 0 clean / 2 integrity / 3 strict-only. To fix locally:
 #
-#     uvx --from "git+https://github.com/txemi/darnlink@v0.1.1" darnlink . --write
+#     uvx --from "git+https://github.com/txemi/darnlink@v0.5.0" darnlink . --robustify --write
 #
 # Shared by the three gates so the logic lives in one place:
 #   - pre-commit  (.pre-commit-config.yaml)
@@ -28,12 +29,12 @@
 #       build the uuid index, so scan the repo root, not a single file.
 set -euo pipefail
 
-# Pinned to an immutable commit SHA (== tag v0.1.1). Tags can be force-moved,
+# Pinned to an immutable commit SHA (== tag v0.5.0). Tags can be force-moved,
 # which would weaken CI reproducibility / supply-chain integrity, so we pin the
 # SHA and keep the tag only as a human-readable note.
-DARNLINK_REF="${DARNLINK_REF:-5929bb50590a86970a011d15e2f19a7e26e5a7c9}"  # v0.1.1
+DARNLINK_REF="${DARNLINK_REF:-70c142e9361eeead3d676cf71d384706bea17c78}"  # v0.5.0
 DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK_REF}}"
 SCAN_ROOT="${1:-.}"
 
-echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (read-only)"
-exec uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}"
+echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (check: integrity + strict, read-only)"
+exec uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}"

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -20,7 +20,7 @@
 #   - GitHub Actions (.github/workflows/docs-links.yml)
 #
 # Env overrides:
-#   DARNLINK_REF   git ref of darnlink to use   (default: immutable SHA of v0.1.1)
+#   DARNLINK_REF   git ref of darnlink to use   (default: immutable SHA of v0.5.0)
 #   DARNLINK_FROM  full uvx --from spec (path or git+)  (default: the pinned SHA)
 #                  e.g. DARNLINK_FROM=/path/to/local/darnlink for local dev
 #


### PR DESCRIPTION
## Qué

Lleva immich-autotag al patrón de robustez de darnlink que ya está en el resto del parque: **enlaces robustecidos + gate estricto (`check`) fijado a darnlink v0.5.0**.

### 1. Robustify (5 enlaces)
Ancla los 5 enlaces Markdown planos cuyo destino **ya tiene `uuid`** con el comentario invisible `<!-- uuid: … -->`, para que se auto-reparen al mover/renombrar el destino:
- `CHANGELOG.md` ×1 (→ `docs/dev/versioning_workflow.md`)
- `README.md` ×4 (→ `docs/development.md` ×3, `docs/CONTRIBUTING.md` ×1)

**Invisible en el Markdown renderizado** (solo cambia el fuente).

### 2. Gate: `repair` → `check`, v0.1.1 → v0.5.0
`scripts/devtools/darnlink_docs_gate.sh` (el único wrapper, compartido por pre-commit + Actions + Jenkins):
- Sube darnlink **v0.1.1 → v0.5.0** (SHA inmutable `70c142e…`, se conserva el pin supply-chain).
- Cambia `darnlink .` (solo integridad) → **`darnlink check`** (integridad **+ strict** en una pasada, exit 0/2/3). Ahora es **fail-closed** también ante un enlace plano anclable sin anclar.

## Verificación
`darnlink check` pasa **limpio (exit 0)** tras el robustify. Los 3 surfaces llaman al mismo wrapper → se mueven juntos.

## Notas
- darnlink v0.5.0 trae `check` (ambos ejes en un comando, no se olvida un eje) y el fix de `mode=repair` (review de Copilot en darnlink#10).
- immich mantiene su wrapper propio (SHA-pin deliberado) en vez de la receta genérica compartida — es un solo fichero, sin drift que unificar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)