### PR TITLE
docs-gate: run darnlink check before robustify (full max: integrity+strict)

### DIFF
--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -28,7 +28,7 @@
 #   - GitHub Actions (.github/workflows/docs-links.yml)
 #
 # Env overrides:
-#   DARNLINK_REF   git ref of darnlink to use   (default: immutable SHA of v0.5.0)
+#   DARNLINK_REF   git ref of darnlink to use   (default: immutable SHA of v0.16.0)
 #   DARNLINK_FROM  full uvx --from spec (path or git+)  (default: the pinned SHA)
 #                  e.g. DARNLINK_FROM=/path/to/local/darnlink for local dev
 #
@@ -37,7 +37,7 @@
 #       build the uuid index, so scan the repo root, not a single file.
 set -euo pipefail
 
-# Pinned to an immutable commit SHA (== tag v0.7.1). Tags can be force-moved,
+# Pinned to an immutable commit SHA (== tag v0.16.0). Tags can be force-moved,
 # which would weaken CI reproducibility / supply-chain integrity, so we pin the
 # SHA and keep the tag only as a human-readable note.
 DARNLINK_REF="${DARNLINK_REF:-bda64d172b05cb546f485a0c4be40d8763796354}"  # v0.16.0
@@ -45,4 +45,8 @@ DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK
 SCAN_ROOT="${1:-.}"
 
 echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (max: fail-closed, read-only)"
+# mode=max = check (integrity + strict) UNION create-frontmatter. `check` catches broken robust
+# links + un-anchored plain links; the second pass catches plain links whose target has no uuid.
+# `set -e` aborts on the first failure -> a true superset of both axes.
+uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}"
 exec uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}" --robustify --create-frontmatter

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -8,15 +8,17 @@
 # (frontmatter + an inline `<!-- uuid: ... -->` comment). When a file moves,
 # the path in the link goes stale but the uuid still points at the target.
 #
-# This gate runs at the MAXIMUM (fail-closed) level, report-only (NO --write):
+# This gate runs at the MAXIMUM (fail-closed) level, report-only (NO --write),
+# as TWO passes (mode=max = the union of both axes; `set -e` aborts on the first):
 #
-#     darnlink . --robustify --create-frontmatter
+#     darnlink check .                          # integrity + strict axis
+#     darnlink . --robustify --create-frontmatter   # create-frontmatter axis
 #
 # It fails the build if ANY internal Markdown link points at a file that does
 # not carry a `uuid` in its frontmatter. In other words: every link target is
 # uuid-anchored, so no refactor (moving/renaming a file or a whole subtree) can
-# ever silently break a link — darnlink can always re-anchor by uuid. This is
-# strictly stronger than the previous `darnlink check` (integrity + strict);
+# ever silently break a link — darnlink can always re-anchor by uuid. The added
+# `check` pass also covers integrity + strict (broken robust links / un-anchored);
 # it additionally requires that *linkable* targets be uuid-bearing.
 # Exit 0 = clean, non-zero = findings. To fix locally (writes uuids):
 #


### PR DESCRIPTION
## What

`scripts/devtools/darnlink_docs_gate.sh` ran only `darnlink . --robustify --create-frontmatter`
(the create-frontmatter axis). That **drops the integrity+strict axis** of `darnlink check`: a broken
robust link, or a plain anchorable link left un-anchored, would sail through the gate.

This adds a `darnlink check` pass **before** the robustify pass, so the gate is `mode=max` complete —
the union of both axes — matching the rest of txemi's darnlink fleet (`darnlink-gate` recipe does the
same two-pass max). `set -e` aborts on the first failure.

Also fixes stale version comments (v0.5.0 / v0.7.1 → **v0.16.0**, the pinned SHA `bda64d17`).

## Verified
- `bash scripts/devtools/darnlink_docs_gate.sh .` → **check exit 0 (clean) + robustify 0 plain links** → rc 0.

## Note (web axis)
Not added here: immich-autotag's only cross-repo web link is a self-link whose target has no `uuid`
(nothing to anchor), and web-check `--online` in a pre-commit-framework hook would do a network call on
every commit for ~zero value. Can be added (env-gated, pre-push/CI only) later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)