### PR TITLE
docs-gate: add web-check pass (max complete) + anchor 7 cross-repo web links

### DIFF
--- a/docs/issues/0033-community/subtasks/0011-announcement-tracking/github-discussions/2026-02-01-announcement_2026.md
+++ b/docs/issues/0033-community/subtasks/0011-announcement-tracking/github-discussions/2026-02-01-announcement_2026.md
@@ -27,7 +27,7 @@ I'm excited to announce a major new release of **Immich AutoTag**, the open-sour
 
 ## Get Started
 - See the [README](https://github.com/txemi/immich-autotag#quick-start) for instant setup instructions.
-- Full changelog: [CHANGELOG.md](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md)
+- Full changelog: [CHANGELOG.md](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md) <!-- web-uuid: 2582dca7-b9de-491d-a906-7603c2d682b8 -->
 
 ## Feedback & Support
 - Questions, issues, or feature requests? Open a ticket on [GitHub Issues](https://github.com/txemi/immich-autotag/issues).

--- a/docs/issues/0033-community/subtasks/0011-announcement-tracking/github-discussions/2026-03-31-announcement_2026.md
+++ b/docs/issues/0033-community/subtasks/0011-announcement-tracking/github-discussions/2026-03-31-announcement_2026.md
@@ -36,8 +36,8 @@ Tracked at [GitHub Issue #43](https://github.com/txemi/immich-autotag/issues/43)
 - 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md)
 - 🏠 [Homepage](https://github.com/txemi/immich-autotag)
 - 📖 [Quick Start (README)](https://github.com/txemi/immich-autotag#quick-start)
-- 📋 [Full Changelog](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md)
-- 🐣 [Explain Like I'm 5](https://github.com/txemi/immich-autotag/blob/main/docs/explain-like-im-5.md)
+- 📋 [Full Changelog](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md) <!-- web-uuid: 2582dca7-b9de-491d-a906-7603c2d682b8 -->
+- 🐣 [Explain Like I'm 5](https://github.com/txemi/immich-autotag/blob/main/docs/explain-like-im-5.md) <!-- web-uuid: 5246c36f-d80d-4eec-80a7-920e5a6dba68 -->
 
 ## Feedback & Support
 

--- a/docs/issues/0033-community/subtasks/0011-announcement-tracking/reddit/2026-02-01-announcement_2026.md
+++ b/docs/issues/0033-community/subtasks/0011-announcement-tracking/reddit/2026-02-01-announcement_2026.md
@@ -25,14 +25,14 @@ Why use Immich AutoTag?
 
 Get Started
 - See the [README](https://github.com/txemi/immich-autotag#quick-start) for instant setup instructions.
-- Full changelog: [CHANGELOG.md](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md)
+- Full changelog: [CHANGELOG.md](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md) <!-- web-uuid: 2582dca7-b9de-491d-a906-7603c2d682b8 -->
 
 Feedback & Support
 - Questions, issues, or feature requests? Open a ticket on [GitHub Issues](https://github.com/txemi/immich-autotag/issues).
 
 Previous Reddit discussion: https://www.reddit.com/r/immich/comments/1pse1qk/comment/nvcmpf0/
 
-For a super simple, non-technical explanation of what Immich AutoTag does, see: [Explain Like I'm 5 (ELI5)](https://github.com/txemi/immich-autotag/blob/main/docs/explain-like-im-5.md)
+For a super simple, non-technical explanation of what Immich AutoTag does, see: [Explain Like I'm 5 (ELI5)](https://github.com/txemi/immich-autotag/blob/main/docs/explain-like-im-5.md) <!-- web-uuid: 5246c36f-d80d-4eec-80a7-920e5a6dba68 -->
 
 Thank you for your support and feedback!
 

--- a/docs/releases/v0.80.0-announcement.md
+++ b/docs/releases/v0.80.0-announcement.md
@@ -32,8 +32,8 @@ Tracked at [GitHub Issue #43](https://github.com/txemi/immich-autotag/issues/43)
 - 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md)
 - 🏠 [Homepage](https://github.com/txemi/immich-autotag)
 - 📖 [Quick Start (README)](https://github.com/txemi/immich-autotag#quick-start)
-- 📋 [Full Changelog](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md)
-- 🐣 [Explain Like I'm 5](https://github.com/txemi/immich-autotag/blob/main/docs/explain-like-im-5.md)
+- 📋 [Full Changelog](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md) <!-- web-uuid: 2582dca7-b9de-491d-a906-7603c2d682b8 -->
+- 🐣 [Explain Like I'm 5](https://github.com/txemi/immich-autotag/blob/main/docs/explain-like-im-5.md) <!-- web-uuid: 5246c36f-d80d-4eec-80a7-920e5a6dba68 -->
 
 ## Feedback & Support
 

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -47,8 +47,16 @@ DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK
 SCAN_ROOT="${1:-.}"
 
 echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (max: fail-closed, read-only)"
-# mode=max = check (integrity + strict) UNION create-frontmatter. `check` catches broken robust
-# links + un-anchored plain links; the second pass catches plain links whose target has no uuid.
-# `set -e` aborts on the first failure -> a true superset of both axes.
+# mode=max = check (integrity + strict) UNION create-frontmatter UNION web. `check` catches broken
+# robust links + un-anchored plain links; the 2nd pass catches plain links whose target has no uuid;
+# the 3rd (web) verifies cross-repo GitHub links still resolve to the destination's uuid (read online).
+# `set -e` aborts on the first failure -> a true superset of all axes.
 uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}"
-exec uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}" --robustify --create-frontmatter
+uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}" --robustify --create-frontmatter
+
+# WEB axis: cross-repo links to PUBLIC repos must still resolve to the destination file's uuid (read
+# online, tokenless). Anchored with `<!-- web-uuid: X -->`. Fail-closed on a broken cross-repo link.
+# Skippable offline (DARNLINK_SKIP_WEB=1, e.g. a disconnected pre-commit); pre-push/CI always has network.
+if [ "${DARNLINK_SKIP_WEB:-0}" != "1" ]; then
+  exec uvx --from "${DARNLINK_FROM}" darnlink web-check "${SCAN_ROOT}" --online
+fi

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -9,10 +9,11 @@
 # the path in the link goes stale but the uuid still points at the target.
 #
 # This gate runs at the MAXIMUM (fail-closed) level, report-only (NO --write),
-# as TWO passes (mode=max = the union of both axes; `set -e` aborts on the first):
+# as THREE passes (mode=max = the union of all axes; `set -e` aborts on the first):
 #
 #     darnlink check .                          # integrity + strict axis
 #     darnlink . --robustify --create-frontmatter   # create-frontmatter axis
+#     darnlink web-check . --online             # web axis (cross-repo links; skip: DARNLINK_SKIP_WEB=1)
 #
 # It fails the build if ANY internal Markdown link points at a file that does
 # not carry a `uuid` in its frontmatter. In other words: every link target is


### PR DESCRIPTION
## What

The docs gate ran `check` + `robustify` (integrity + strict + create-frontmatter) but **did not watch
cross-repo WEB links**. Audit found **7 anchorable web links** (announcement docs → github-discussions /
reddit / releases, pointing to GitHub files with a `uuid`) that were being missed.

This PR:
1. **Anchors the 7 web links** (`web-check --online --write` → `<!-- web-uuid: X -->`).
2. **Adds a 3rd gate pass** `web-check --online` to `darnlink_docs_gate.sh` so those links stay verified
   (fail-closed on a broken cross-repo link). Tokenless (public destinations). Skippable offline via
   `DARNLINK_SKIP_WEB=1`; pre-push/CI always has network.

Now immich-autotag's gate is **max complete** — `check + robustify + web` — matching the rest of the
darnlink fleet.

## Verified
- `bash scripts/devtools/darnlink_docs_gate.sh .` → check exit 0 (strict 0) + robustify 0 + **web: ok 7, not-found 0** → rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)