### PR TITLE
ci: scrub internal infrastructure references and add a privacy gate

### DIFF
--- a/.claude/commands/sync-config.md
+++ b/.claude/commands/sync-config.md
@@ -28,4 +28,4 @@ Synchronise the private config file with the latest template, preserving all per
 2. Identify differences: what the template has that the private config lacks or has outdated.
 3. Show a brief summary of the planned changes before editing.
 4. Apply the changes to `~/.config/immich_autotag/config.py`.
-5. Verify the updated file loads without errors: `python -m immich_autotag.config.user_config_template` equivalent — run `python -c "exec(open('~/.config/immich_autotag/config.py').read())" 2>&1 | tail -3` and confirm no traceback.
+5. Verify the updated file loads without errors: `python -m immich_autotag.config.user_config_template` equivalent — run `python -c "import os; exec(open(os.path.expanduser('~/.config/immich_autotag/config.py')).read())" 2>&1 | tail -3` and confirm no traceback.

--- a/.claude/commands/sync-config.md
+++ b/.claude/commands/sync-config.md
@@ -28,4 +28,4 @@ Synchronise the private config file with the latest template, preserving all per
 2. Identify differences: what the template has that the private config lacks or has outdated.
 3. Show a brief summary of the planned changes before editing.
 4. Apply the changes to `~/.config/immich_autotag/config.py`.
-5. Verify the updated file loads without errors: `python -m immich_autotag.config.user_config_template` equivalent — run `python -c "exec(open('/home/txemi/.config/immich_autotag/config.py').read())" 2>&1 | tail -3` and confirm no traceback.
+5. Verify the updated file loads without errors: `python -m immich_autotag.config.user_config_template` equivalent — run `python -c "exec(open('~/.config/immich_autotag/config.py').read())" 2>&1 | tail -3` and confirm no traceback.

--- a/.github/privacy-gate-baseline.txt
+++ b/.github/privacy-gate-baseline.txt
@@ -1,0 +1,10 @@
+# Pre-existing private references, tolerated so the gate can be adopted today.
+# Format: file:line. Never the offending text — this file is public.
+# This list may only shrink. Adding to it means letting a new leak through.
+
+# The Jenkins credential ID embeds the CI host's internal name. Unlike the rest, this is CODE, not
+# documentation: `withCredentials` resolves it against a credential that exists in Jenkins under
+# exactly this id, so editing the string alone breaks tag pushing. Clearing it is an infrastructure
+# change, in this order: create the credential again in Jenkins under a neutral id, point the
+# Jenkinsfile at it, delete the old one, then delete this line.
+Jenkinsfile:17

--- a/.github/workflows/privacy-gate.yml
+++ b/.github/workflows/privacy-gate.yml
@@ -1,0 +1,129 @@
+# Privacy gate — blocks private references from reaching this public repo.
+#
+# WHY THIS EXISTS. An audit on 2026-08-08 across every public repository of this account found
+# private identifiers in two of them. Here it was internal infrastructure: the hostname and domain
+# of a private CI server, pasted as build URLs into a debugging note, and a local home path in an
+# agent command. No credential ever leaked. It got in through *examples* — a note records what
+# actually happened, and what actually happened was on a private network. That is not something a
+# one-off review catches, because the next debugging note re-introduces it. So it is a gate.
+#
+# WHAT IT CHECKS, and why each surface matters:
+#   1. Tracked files      — recoverable with a commit, but permanent in git history.
+#   2. PR title and body  — the worst surface. Rendered as public HTML, indexed by search engines,
+#                           and IMPOSSIBLE to retract: editing a PR body keeps the previous text
+#                           readable through the API (userContentEdits), and PR bodies cannot be
+#                           deleted. Catching these before merge is the only chance there is.
+#   3. Commit messages    — cannot be changed after push without rewriting history.
+#
+# THE PATTERN LIST IS A SECRET (`PRIVACY_DENYLIST`, one extended-regex per line) for the obvious
+# reason: a list of private names cannot live in the repo it is protecting.
+#
+# TWO DELIBERATE CHOICES:
+#   - FAIL-CLOSED on a missing secret. If the list is absent the job fails instead of passing, so a
+#     misconfigured repo can never look green while checking nothing.
+#   - NEVER PRINT THE MATCH. CI logs on a public repo are public, so reporting the offending text
+#     would leak it in the very place meant to prevent that. Only `file:line` is printed. (Actions
+#     would mask the value anyway; this does not rely on that.)
+name: privacy-gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan for private references
+        env:
+          DENYLIST: ${{ secrets.PRIVACY_DENYLIST }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          # Orden de BYTES, no del locale. `comm` exige que sus dos entradas esten ordenadas con el
+          # mismo criterio que el suyo; con un locale como es_ES.UTF-8, `sort` colaciona distinto y
+          # comm empieza a dar entradas del baseline como si fueran nuevas. Visto en pruebas.
+          export LC_ALL=C
+
+          if [ -z "${DENYLIST:-}" ]; then
+            echo "::error::PRIVACY_DENYLIST secret is not set. Failing closed:"
+            echo "a privacy gate with no patterns would report success while checking nothing."
+            exit 1
+          fi
+          printf '%s\n' "$DENYLIST" | grep -v '^[[:space:]]*$' > /tmp/denylist.txt
+          # Re-check AFTER stripping blank lines, not only before. A secret holding nothing but
+          # whitespace passes the -z test above and then leaves zero patterns, and GNU grep -f with
+          # an empty pattern file matches NOTHING and exits 1 -> every surface would report "clean"
+          # while checking nothing, which is exactly the failure this job exists to make impossible.
+          # (Worth knowing: ugrep does the opposite on the same input, so a local test can disagree
+          # with the runner. Hence an explicit check instead of relying on either behaviour.)
+          if [ ! -s /tmp/denylist.txt ]; then
+            echo "::error::PRIVACY_DENYLIST contains no usable patterns (blank/whitespace only)."
+            echo "Failing closed rather than scanning with an empty pattern set."
+            exit 1
+          fi
+          echo "Patterns loaded: $(wc -l < /tmp/denylist.txt) (contents intentionally not printed)"
+
+          fail=0
+
+          # Baseline of pre-existing violations, as `file:line`, same idea as the entity-structure
+          # baseline in the documentation monorepo: adopt the gate on a repo that is not clean yet,
+          # then let the list only ever shrink. It holds file:line and never the offending text, so
+          # the baseline itself is safe to keep in a public repo. Being brittle is deliberate — if
+          # the line moves, the entry stops matching and the case comes back for a fresh look.
+          BASELINE=.github/privacy-gate-baseline.txt
+          grep -v '^[[:space:]]*\(#\|$\)' "$BASELINE" 2>/dev/null | sort -u > /tmp/baseline.txt || : > /tmp/baseline.txt
+          echo "Baseline entries: $(wc -l < /tmp/baseline.txt)"
+
+          # 1. Tracked files. Only file:line is reported — never the matching text.
+          echo "--- tracked files ---"
+          git ls-files -z | xargs -0 grep -nIiEf /tmp/denylist.txt 2>/dev/null \
+            | cut -d: -f1,2 | sort -u > /tmp/all_hits.txt || :
+          comm -23 /tmp/all_hits.txt /tmp/baseline.txt > /tmp/hits.txt
+          if [ -s /tmp/hits.txt ]; then
+            sed 's/^/  /' /tmp/hits.txt
+            echo "::error::private reference(s) found in tracked files (see file:line above)"
+            fail=1
+          else
+            echo "  clean ($(comm -12 /tmp/all_hits.txt /tmp/baseline.txt | wc -l) known, in baseline)"
+          fi
+          # Una entrada del baseline que ya no casa es deuda saldada: fuera, para que no pueda volver.
+          if [ -n "$(comm -13 /tmp/all_hits.txt /tmp/baseline.txt)" ]; then
+            echo "::warning::baseline entries no longer matching — remove them from $BASELINE:"
+            comm -13 /tmp/all_hits.txt /tmp/baseline.txt | sed 's/^/  /'
+          fi
+
+          # 2. PR title and body. Unretractable once merged — this is the important one.
+          if [ -n "${PR_BODY:-}${PR_TITLE:-}" ]; then
+            echo "--- pull request title/body ---"
+            if printf '%s\n%s\n' "${PR_TITLE:-}" "${PR_BODY:-}" | grep -qiEf /tmp/denylist.txt; then
+              echo "::error::private reference in the PR title or body. Edit it BEFORE merging:"
+              echo "editing later does not remove it (the old revision stays readable via the API)."
+              fail=1
+            else
+              echo "  clean"
+            fi
+          fi
+
+          # 3. Commit messages introduced by this PR.
+          if [ -n "${BASE_SHA:-}" ]; then
+            echo "--- commit messages ---"
+            if git log --format='%s%n%b' "${BASE_SHA}..HEAD" | grep -qiEf /tmp/denylist.txt; then
+              echo "::error::private reference in a commit message: amend/rebase before merging."
+              fail=1
+            else
+              echo "  clean"
+            fi
+          fi
+
+          exit $fail

--- a/docs/issues/0024-album-features/subtasks/0016-auto-album-creation/subtasks/004-temp-album-false-positive-classified-assets/ai-context.md
+++ b/docs/issues/0024-album-features/subtasks/0016-auto-album-creation/subtasks/004-temp-album-false-positive-classified-assets/ai-context.md
@@ -85,8 +85,8 @@ At the time, two Jenkins builds were running simultaneously on `fix/conversion-a
 
 | Build | Started | Status at discovery |
 |---|---|---|
-| [#4](http://ubuntu20jenkins.ad3.lab:8080/job/immich-autotag/job/fix%252Fconversion-album-move/4/) | 2026-04-24 12:34 | Conversion phase, ~78%, removing `autotag_output_unknown` |
-| [#13](http://ubuntu20jenkins.ad3.lab:8080/job/immich-autotag/job/fix%252Fconversion-album-move/13/) | 2026-04-25 19:54 | Classification phase, ~9.5%, active `autotag_input_meme` removals |
+| #4 | 2026-04-24 12:34 | Conversion phase, ~78%, removing `autotag_output_unknown` |
+| #13 | 2026-04-25 19:54 | Classification phase, ~9.5%, active `autotag_input_meme` removals |
 
 **Both builds were stopped.** On 2026-04-26 the second Jenkins node was taken down to prevent parallel runs and make future runs easier to diagnose.
 


### PR DESCRIPTION
An audit across every public repository of this account found private identifiers in two of them. Here it was **internal infrastructure**, not secrets — no credential leaked.

## What was in the tree

| Where | What | Fix |
|---|---|---|
| a debugging note | two build URLs carrying the CI server's internal hostname and domain | link removed, **build number kept** — the number was the information, and the URL has not resolved from outside the LAN for months |
| an agent command | a hardcoded local home path | `~`, which the shell expands to the same thing |
| `Jenkinsfile` | the credential id embeds the CI host's internal name | **baselined, not touched** — see below |

Both leaks arrived the same way: a note recording what actually happened, where what happened was on a private network. That is not something a one-off review catches, because the next note re-introduces it.

## The gate

Scans tracked files, the **PR title and body**, and the commit messages a PR introduces. The PR body is the one that matters: public, indexed, and unretractable — editing it leaves the previous revision readable through the API, and a body cannot be deleted, so before merge is the only chance.

- Pattern list lives in the `PRIVACY_DENYLIST` secret, since a list of private names cannot live in the repo it protects.
- **Fails closed** if that secret is missing *or* resolves to zero patterns.
- **Never prints the match** — these CI logs are public, so printing the offending text would leak it in the place meant to prevent that. Output is `file:line` only.

## Why there is a baseline

The Jenkins `credentialsId` is **code, not prose**: `withCredentials` resolves it against a credential registered in Jenkins under exactly that id, so editing the string alone breaks tag pushing. Clearing it is an infrastructure change — recreate the credential under a neutral id, repoint the Jenkinsfile, delete the old one — so it is recorded in `.github/privacy-gate-baseline.txt` with those steps rather than quietly broken.

This mirrors the entity-structure baseline already used in the documentation monorepo: adopt the gate now, let the list only shrink. The baseline holds `file:line` and never the offending text, so it is safe in a public repo, and it is deliberately brittle — if the line moves, the entry stops matching and the case comes back for a fresh look.

Verified locally against the runner's GNU grep: current tree passes with the single baselined entry, and a freshly injected internal URL is caught while the baselined one stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)