### PR TITLE
ci(privacy-gate): comments to English — the repo's own gate forbids Spanish

### DIFF
--- a/.github/workflows/privacy-gate.yml
+++ b/.github/workflows/privacy-gate.yml
@@ -50,9 +50,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -uo pipefail
-          # Orden de BYTES, no del locale. `comm` exige que sus dos entradas esten ordenadas con el
-          # mismo criterio que el suyo; con un locale como es_ES.UTF-8, `sort` colaciona distinto y
-          # comm empieza a dar entradas del baseline como si fueran nuevas. Visto en pruebas.
+          # BYTE order, not locale order. `comm` requires both of its inputs to be sorted with
+          # the same collation it uses itself; under a locale such as es_ES.UTF-8, `sort` collates
+          # differently and `comm` starts reporting baseline entries as if they were new. Seen in
+          # testing.
           export LC_ALL=C
 
           if [ -z "${DENYLIST:-}" ]; then


### PR DESCRIPTION
## What

Three comment lines in `.github/workflows/privacy-gate.yml` are in Spanish, and the repo's own `check_no_spanish_chars` quality gate rejects them. Translated to English; the content is preserved.

## Why it matters (it is not cosmetic)

On `main` the failure is invisible, because `main` is red for a different reason (corrupted `.venv` in the Jenkins agent workspace → cannot clone). But **any branch that merges `main` inherits a workflow file that fails the gate.**

That is exactly what happened on 2026-08-09 on the operational branch `ops/batch-processing`, which runs the photo-classification chain:

```
#353  SUCCESS  84 min   30.000 assets classified
#354  FAILURE  24 min   check_no_spanish_chars: 3 findings
#355  FAILURE  18 min   idem
```

Both failed **before reaching `Run Application`** — 42 minutes burned without classifying a single photo. Already fixed on that branch (`d353a0f`); this PR fixes it at the source.

## The comment is worth keeping

It documents why `LC_ALL=C` is required: without it, `sort` collates by locale and `comm` starts reporting baseline entries as if they were new. Only the language changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)