### PR TITLE
ci(docs-gate): stop scanning logs_local/ — the job was failing on its own output

### DIFF
--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -53,17 +53,32 @@ DARNLINK_REF="${DARNLINK_REF:-66a9647b2a78fcde65635af8660696cb948e7105}" # v0.20
 DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK_REF}}"
 SCAN_ROOT="${1:-.}"
 
+# EXCLUDES: directories the gate must not walk.
+#
+# `logs_local/` is RUNTIME OUTPUT, not documentation: the batch writes a fresh
+# `immich_autotag_links.md` (plus an `_archive/cycle-*/` tree) on every pass, and
+# `.gitignore` already excludes it -- none of it is tracked. Without this the gate
+# demanded `web-uuid` anchors on files the job had just generated, so the pipeline
+# failed on its own output: build #358 of ops/batch-processing died with 24 pending
+# anchors, every one of them under logs_local/. Anchoring them would not have fixed
+# anything either -- the next run regenerates them unanchored.
+#
+# This is repo-wide on purpose, not branch-specific: Jenkinsfile runs run_app.sh on
+# EVERY branch and archives logs_local/*_PID*/**, so main produces them too and would
+# hit the same wall as soon as it got past the earlier gates.
+DARNLINK_EXCLUDES=(--exclude 'logs_local' --exclude '_archive')
+
 echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (max: fail-closed, read-only)"
 # mode=max = check (integrity + strict) UNION create-frontmatter UNION web. `check` catches broken
 # robust links + un-anchored plain links; the 2nd pass catches plain links whose target has no uuid;
 # the 3rd (web) verifies cross-repo GitHub links still resolve to the destination's uuid (read online).
 # `set -e` aborts on the first failure -> a true superset of all axes.
-uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}"
-uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}" --robustify --create-frontmatter
+uvx --from "${DARNLINK_FROM}" darnlink check "${DARNLINK_EXCLUDES[@]}" "${SCAN_ROOT}"
+uvx --from "${DARNLINK_FROM}" darnlink "${DARNLINK_EXCLUDES[@]}" "${SCAN_ROOT}" --robustify --create-frontmatter
 
 # WEB axis: cross-repo links to PUBLIC repos must still resolve to the destination file's uuid (read
 # online, tokenless). Anchored with `<!-- web-uuid: X -->`. Fail-closed on a broken cross-repo link.
 # Skippable offline (DARNLINK_SKIP_WEB=1, e.g. a disconnected pre-commit); pre-push/CI always has network.
 if [ "${DARNLINK_SKIP_WEB:-0}" != "1" ]; then
-	exec uvx --from "${DARNLINK_FROM}" darnlink web-check "${SCAN_ROOT}" --online
+	exec uvx --from "${DARNLINK_FROM}" darnlink web-check "${DARNLINK_EXCLUDES[@]}" "${SCAN_ROOT}" --online
 fi

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -66,19 +66,24 @@ SCAN_ROOT="${1:-.}"
 # This is repo-wide on purpose, not branch-specific: Jenkinsfile runs run_app.sh on
 # EVERY branch and archives logs_local/*_PID*/**, so main produces them too and would
 # hit the same wall as soon as it got past the earlier gates.
-DARNLINK_EXCLUDES=(--exclude 'logs_local' --exclude '_archive')
+#
+# ONE entry, not two. The archived cycles live at logs_local/_archive/cycle-*, so they
+# are already covered. Excluding '_archive' as well would be redundant here and too
+# broad everywhere else: excludes are directory-NAME globs, so it would silently skip
+# any _archive/ added anywhere in the repo later. Narrow beats convenient in a gate.
+DARNLINK_EXCLUDES=(--exclude 'logs_local')
 
 echo "darnlink docs-link gate — scanning '${SCAN_ROOT}' via '${DARNLINK_FROM}' (max: fail-closed, read-only)"
 # mode=max = check (integrity + strict) UNION create-frontmatter UNION web. `check` catches broken
 # robust links + un-anchored plain links; the 2nd pass catches plain links whose target has no uuid;
 # the 3rd (web) verifies cross-repo GitHub links still resolve to the destination's uuid (read online).
 # `set -e` aborts on the first failure -> a true superset of all axes.
-uvx --from "${DARNLINK_FROM}" darnlink check "${DARNLINK_EXCLUDES[@]}" "${SCAN_ROOT}"
-uvx --from "${DARNLINK_FROM}" darnlink "${DARNLINK_EXCLUDES[@]}" "${SCAN_ROOT}" --robustify --create-frontmatter
+uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}"
+uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}" --robustify --create-frontmatter
 
 # WEB axis: cross-repo links to PUBLIC repos must still resolve to the destination file's uuid (read
 # online, tokenless). Anchored with `<!-- web-uuid: X -->`. Fail-closed on a broken cross-repo link.
 # Skippable offline (DARNLINK_SKIP_WEB=1, e.g. a disconnected pre-commit); pre-push/CI always has network.
 if [ "${DARNLINK_SKIP_WEB:-0}" != "1" ]; then
-	exec uvx --from "${DARNLINK_FROM}" darnlink web-check "${DARNLINK_EXCLUDES[@]}" "${SCAN_ROOT}" --online
+	exec uvx --from "${DARNLINK_FROM}" darnlink web-check "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}" --online
 fi


### PR DESCRIPTION
## The bug

Build **#358** of `ops/batch-processing` passed the **entire** quality battery:

```
check_shfmt OK · check_isort OK · check_ssort OK · check_black OK · check_ruff OK
check_mypy OK · check_import_linter OK · check_no_tuples OK · check_jscpd OK …
[OK] Battery passed!
```

…and then died in the **docs-link gate** with **24 pending `web-uuid` anchors**. Every single one under `logs_local/`:

```
logs_local/20260730_050243_PID8568/immich_autotag_links.md
logs_local/_archive/cycle-20260729_173339/…/immich_autotag_links.md   (×23)
```

**The pipeline was failing on files it had just generated itself.**

## Why excluding is the fix, and anchoring is not

`logs_local/` is **runtime output, not documentation**. The batch writes a fresh `immich_autotag_links.md` on every pass and archives the previous cycle under `_archive/`. And `.gitignore` line 15 already says `/logs_local` — **nothing in there is tracked**.

Anchoring those 24 files would fix exactly one build: the next run regenerates them unanchored and the wall is back tomorrow. The gate exists so the repo's **documentation** survives refactors; walking generated output is the defect.

## Why this belongs in `main`, not in the operational branch

`Jenkinsfile:150` runs `run_app.sh` on **every** branch and `post.always` archives `logs_local/*_PID*/**`, so **`main` produces these files too** and would hit the same wall as soon as it got past the earlier gates. It has not hit it yet only because build #38 died earlier, on `check_shfmt` (fixed in #67).

Putting this only on the branch would recreate exactly the divergence #67 had to repair: two July fixes that lived on `ops/batch-processing` and `main` never received.

## Verification

- Applied to the **three** axes (`check`, `--robustify`, `web-check`) so no pass walks it.
- `shfmt -d -i 0 scripts/` → clean. `bash -n` → OK.
- Excludes are directory-name globs (`--exclude 'logs_local' --exclude '_archive'`), per `darnlink --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)