### PR TITLE
ci(jenkins): bind the pipeline to a purpose label, not to a machine name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ def ENABLE_JENKINS_TAGGING = true // Set to true to enable GitHub tagging
 // Auto-chain: on success the build re-triggers itself, so the batch keeps walking the library
 // without anyone pressing a button. It belongs ONLY to the operational branch: on any other
 // branch it would spin a second infinite loop competing for the SAME single agent
-// (ub20jenkins4ub20), where each run can take hours. main is for validating, not for
-// processing the library.
+// (the one carrying the `immich-batch` label), where each run can take hours. main is
+// for validating, not for processing the library.
 def ENABLE_AUTO_CHAIN = (env.BRANCH_NAME == 'ops/batch-processing')
                                   // (keeps the batch-processing chain self-perpetuating
                                   // without external dispatch). Failure stops the chain

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,11 +42,24 @@ pipeline {
     agent {
         docker {
             image 'python:3.11-slim'
-            // Pin to the batch agent: the checkpoint chain (logs_local/) lives in this
+            // Pin to the batch agent: the checkpoint chain (logs_local/) lives in that
             // node's workspace, and sequential single-node execution is required
             // (see issue 004-active-run-monitoring). Without a label the build can land
             // on the Windows agent (no docker) or the controller.
-            label 'ub20jenkins4ub20'
+            //
+            // The label is a PURPOSE, not a hostname. It used to say
+            // 'ub20jenkins4ub20', which happens to work because Jenkins exposes every
+            // node's own name as an implicit label -- but that is not a label anyone
+            // declared: this controller only defines two, `linux` and `windows`. Binding
+            // the pipeline to a machine name means renaming or replacing that machine
+            // requires a code change and a PR to a protected branch, and it silently
+            // bypasses the label scheme.
+            //
+            // `immich-batch` is declared on the node in Jenkins (2026-08-10). Moving the
+            // batch to another machine is now a checkbox there, not a commit here. NOTE:
+            // it is deliberately assigned to ONE node -- until the checkpoint stops
+            // living in a node's workspace, a second node would reprocess from zero.
+            label 'immich-batch'
             // Mounts ~/.ssh from host into the container as read-only for private key and known_hosts access
             // Ensure $HOME/.ssh exists and contains the required key and known_hosts files
             args '-v $HOME/.cache:/root/.cache -v $HOME/.config/immich_autotag:/root/.config/immich_autotag:ro -v $HOME/.ssh:/root/.ssh:ro --user root'


### PR DESCRIPTION
## The problem

The agent block said:

```groovy
label 'ub20jenkins4ub20'
```

That works — but only because **Jenkins exposes every node's own name as an implicit label**. It is not a label anybody declared. This controller defines exactly **two**: `linux` and `windows`.

So the pipeline was reaching past the label scheme and nailing itself to one machine **by name**. Two costs:

- Renaming or replacing that box needs a **code change and a PR to a protected branch**.
- No other node can ever be considered, however idle.

## What changes

`label 'immich-batch'` — a label declared **on the node, in Jenkins** (added 2026-08-10, *before* this PR, deliberately: the other order would leave every build queued forever looking for a label nobody defines).

Moving the batch to another machine becomes a checkbox in Jenkins instead of a commit here.

## What does NOT change

**The pin is not relaxed.** `immich-batch` is assigned to exactly **one** node on purpose.

The checkpoint chain (`logs_local/`) still lives in that node's workspace, so a build landing elsewhere would reprocess from zero — which is exactly what happened on 2026-08-09 when the operational branch was deleted and its workspace went with it. Spreading this label is a separate decision that depends on first moving the checkpoint out of a workspace.

## Verification

```
node ub20jenkins4ub20 → labels: [ub20jenkins4ub20, linux, immich-batch]
```

Single-line change plus the comment explaining why the label is a purpose and not a hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)