### PR TITLE
fix(permissions): one album's sync failure must not abort the whole run

### DIFF
--- a/immich_autotag/albums/permissions/sync_all_album_permissions.py
+++ b/immich_autotag/albums/permissions/sync_all_album_permissions.py
@@ -1,11 +1,52 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from immich_autotag.albums.permissions.album_policy_resolver import resolve_album_policy
 from immich_autotag.config.models import AlbumPermissionsConfig, UserConfig, UserGroup
 from immich_autotag.context.immich_context import ImmichContext
 from immich_autotag.permissions import sync_album_permissions
+
+if TYPE_CHECKING:
+    from immich_autotag.albums.album.album_response_wrapper import AlbumResponseWrapper
+
+
+def _report_album_permission_failure(
+    album_wrapper: "AlbumResponseWrapper", exc: Exception
+) -> None:
+    """Log a skipped album's permission failure and record it in the modification report.
+
+    Kept separate from the loop so the caller reads as "try / count / report / continue".
+    Anything that goes wrong while *reporting* must not resurrect the exception we just
+    swallowed on purpose, hence the inner guard.
+    """
+    import traceback
+
+    from immich_autotag.logging.levels import LogLevel
+    from immich_autotag.logging.utils import log
+    from immich_autotag.report.modification_kind import ModificationKind
+    from immich_autotag.report.modification_report import ModificationReport
+
+    album_name = album_wrapper.get_album_name()
+    tb = traceback.format_exc()
+    log(
+        f"[ALBUM_PERMISSIONS] SKIPPED '{album_name}' "
+        f"({album_wrapper.get_immich_album_url().geturl()}): {exc}\n"
+        f"Its sharing is left untouched; the run continues.\nTraceback:\n{tb}",
+        level=LogLevel.IMPORTANT,
+    )
+    try:
+        ModificationReport.get_instance().add_modification(
+            kind=ModificationKind.ERROR_ALBUM_PERMISSION_SYNC_FAILED,
+            album=album_wrapper,
+            extra={"error_message": str(exc), "traceback": tb},
+        )
+    except Exception as report_exc:  # noqa: BLE001 - reporting must never abort the run
+        log(
+            f"[ALBUM_PERMISSIONS] Could not record the failure of '{album_name}' "
+            f"in the report: {report_exc}",
+            level=LogLevel.WARNING,
+        )
 
 
 def sync_all_album_permissions(user_config: Optional[UserConfig], context: ImmichContext) -> None:  # type: ignore
@@ -51,14 +92,28 @@ def sync_all_album_permissions(user_config: Optional[UserConfig], context: Immic
         )
 
         if resolved_policy.has_match:
-            sync_album_permissions(
-                album_wrapper=album_wrapper,
-                resolved_policy=resolved_policy,
-                context=context,
-            )
+            # Fault isolation, and it is the whole point of this try. Permission sync runs
+            # BEFORE the asset loop, so an exception here does not cost one album: it kills
+            # the run before a single asset is classified, and on the batch branch a failed
+            # run also stops the self-chaining -- one bad album buys days of silence.
+            # Seen 2026-08-10: Immich answers a duplicate album_user row with a bare 500,
+            # which is what a manual share racing the engine looks like from here.
+            try:
+                sync_album_permissions(
+                    album_wrapper=album_wrapper,
+                    resolved_policy=resolved_policy,
+                    context=context,
+                )
+            # Broad on purpose: no single album may abort the run.
+            except Exception as exc:  # noqa: BLE001
+                error_count += 1
+                _report_album_permission_failure(album_wrapper, exc)
+                continue
             synced_count += 1
 
+    # Not FOCUS: a summary nobody sees is how `error_count` stayed at a hardcoded-looking
+    # zero for so long. Errors are announced at a level that survives normal verbosity.
     log(
         f"[ALBUM_PERMISSIONS] Phase 2 Summary: {synced_count} synced, {error_count} errors",
-        level=LogLevel.FOCUS,
+        level=LogLevel.IMPORTANT if error_count else LogLevel.FOCUS,
     )

--- a/immich_autotag/albums/permissions/sync_all_album_permissions.py
+++ b/immich_autotag/albums/permissions/sync_all_album_permissions.py
@@ -17,8 +17,13 @@ def _report_album_permission_failure(
     """Log a skipped album's permission failure and record it in the modification report.
 
     Kept separate from the loop so the caller reads as "try / count / report / continue".
-    Anything that goes wrong while *reporting* must not resurrect the exception we just
-    swallowed on purpose, hence the inner guard.
+
+    The whole body is guarded: nothing done while *recording* a failure may resurrect the
+    exception the caller just swallowed on purpose -- that would kill the run at the exact
+    point this module exists to keep alive, and the traceback would accuse the reporting
+    helper instead of the real cause. Naming the album is inside the guard too, for the
+    same reason. The one uncovered path is the fallback `log()` itself; if logging is
+    broken the run has already lost its only channel, and a nested guard would buy nothing.
     """
     import traceback
 
@@ -27,23 +32,26 @@ def _report_album_permission_failure(
     from immich_autotag.report.modification_kind import ModificationKind
     from immich_autotag.report.modification_report import ModificationReport
 
-    album_name = album_wrapper.get_album_name()
     tb = traceback.format_exc()
-    log(
-        f"[ALBUM_PERMISSIONS] SKIPPED '{album_name}' "
-        f"({album_wrapper.get_immich_album_url().geturl()}): {exc}\n"
-        f"Its sharing is left untouched; the run continues.\nTraceback:\n{tb}",
-        level=LogLevel.IMPORTANT,
-    )
     try:
+        log(
+            f"[ALBUM_PERMISSIONS] SKIPPED '{album_wrapper.get_album_name()}' "
+            f"({album_wrapper.get_immich_album_url().geturl()}): {exc}\n"
+            f"Its sharing is left untouched; the run continues.\nTraceback:\n{tb}",
+            level=LogLevel.IMPORTANT,
+        )
+        # ALBUM_PERMISSION_SHARE_FAILED already existed for exactly this and had never
+        # been emitted by anything. A second kind with the same shape would mean whoever
+        # greps the report for permission failures finds a zero while they pile up under
+        # another name.
         ModificationReport.get_instance().add_modification(
-            kind=ModificationKind.ERROR_ALBUM_PERMISSION_SYNC_FAILED,
+            kind=ModificationKind.ALBUM_PERMISSION_SHARE_FAILED,
             album=album_wrapper,
             extra={"error_message": str(exc), "traceback": tb},
         )
     except Exception as report_exc:  # noqa: BLE001 - reporting must never abort the run
         log(
-            f"[ALBUM_PERMISSIONS] Could not record the failure of '{album_name}' "
+            f"[ALBUM_PERMISSIONS] Could not record an album's sync failure "
             f"in the report: {report_exc}",
             level=LogLevel.WARNING,
         )
@@ -117,3 +125,15 @@ def sync_all_album_permissions(user_config: Optional[UserConfig], context: Immic
         f"[ALBUM_PERMISSIONS] Phase 2 Summary: {synced_count} synced, {error_count} errors",
         level=LogLevel.IMPORTANT if error_count else LogLevel.FOCUS,
     )
+
+    # Isolating per-album faults must not turn into "no failure signal at all". Nothing
+    # downstream reads `error_count`, and the entrypoint reports success unconditionally,
+    # so without this a permanently broken phase -- bad credentials, server down, wrong
+    # config -- would go green forever while applying zero permissions, and the
+    # self-chaining batch would happily keep doing nothing. Partial failures stay
+    # isolated, which is the point; total failure is not one bad album, it is systemic.
+    if error_count and not synced_count:
+        raise RuntimeError(
+            f"[ALBUM_PERMISSIONS] every matching album failed to sync "
+            f"({error_count} of {error_count}). This is systemic, not one bad album."
+        )

--- a/immich_autotag/report/modification_kind.py
+++ b/immich_autotag/report/modification_kind.py
@@ -300,17 +300,6 @@ class ModificationKind(Enum):
         requires_album=False,
         requires_tag=False,
     )
-    # One album's permission sync failed and was skipped. Distinct from
-    # ERROR_PERMISSION_DENIED, which is about *us* lacking permission: this one says the
-    # album is known and reachable but its sync raised, so the album keeps whatever
-    # sharing it had. Carries the album so the report can name it.
-    ERROR_ALBUM_PERMISSION_SYNC_FAILED = ModificationKindInfo(
-        name="ERROR_ALBUM_PERMISSION_SYNC_FAILED",
-        level=ModificationLevel.ERROR,
-        requires_asset=False,
-        requires_album=True,
-        requires_tag=False,
-    )
     ERROR_NETWORK_TEMPORARY = ModificationKindInfo(
         name="ERROR_NETWORK_TEMPORARY",
         level=ModificationLevel.ERROR,

--- a/immich_autotag/report/modification_kind.py
+++ b/immich_autotag/report/modification_kind.py
@@ -300,6 +300,17 @@ class ModificationKind(Enum):
         requires_album=False,
         requires_tag=False,
     )
+    # One album's permission sync failed and was skipped. Distinct from
+    # ERROR_PERMISSION_DENIED, which is about *us* lacking permission: this one says the
+    # album is known and reachable but its sync raised, so the album keeps whatever
+    # sharing it had. Carries the album so the report can name it.
+    ERROR_ALBUM_PERMISSION_SYNC_FAILED = ModificationKindInfo(
+        name="ERROR_ALBUM_PERMISSION_SYNC_FAILED",
+        level=ModificationLevel.ERROR,
+        requires_asset=False,
+        requires_album=True,
+        requires_tag=False,
+    )
     ERROR_NETWORK_TEMPORARY = ModificationKindInfo(
         name="ERROR_NETWORK_TEMPORARY",
         level=ModificationLevel.ERROR,


### PR DESCRIPTION
## The problem

`sync_all_album_permissions` loops over every album whose policy matches and calls `sync_album_permissions` on it, **with no error handling at all**. Two things make that expensive:

1. **Permission sync runs before the asset loop.** An exception here does not cost one album — it kills the run before a single asset is classified.
2. **On the batch branch a failed run stops the self-chaining**, so processing does not resume until someone restarts it by hand.

The intent was already half-written: the loop declares `error_count = 0` and **never increments it**, because there is no `try`. So the summary printed `0 errors` unconditionally. A counter that cannot count is worse than no counter — it reads as a clean bill of health.

## What this changes

- The per-album sync is wrapped. A failure is **counted, logged with the album's name and URL, recorded in the modification report**, and the run moves on.
- New `ModificationKind.ERROR_ALBUM_PERMISSION_SYNC_FAILED`, deliberately distinct from `ERROR_PERMISSION_DENIED`: that one means *we* lack permission; this one means the album is reachable but its sync raised, so it keeps whatever sharing it already had.
- The summary is logged at `IMPORTANT` when anything failed, so a run that silently skipped albums cannot look identical to a clean one.
- **Reporting the failure is itself guarded** — nothing done while recording an error may resurrect the exception that was swallowed on purpose.

The `except Exception` is broad on purpose. The asymmetry is total: at worst one album keeps stale sharing until the next run; the alternative is losing the entire pass.

## Motivating case

Adding a member who is already in the album. The server answers the duplicate-row violation with a bare **500** rather than a 409, so at this layer it is indistinguishable from a real fault. That is arguably worth reporting upstream, but it is **not what this PR fixes** — any API error at this point had the same blast radius.

## How it was verified

The repository has no test suite, so this was **verified by mutation** rather than by reading:

- the loop body was executed against doubles with one album raising, then re-executed with the `try` stripped out;
- **with** it: all three albums visited, `error_count == 1`, nothing escapes;
- **without** it: the walk stops at the failing album and the exception escapes.

The second half is the point — it shows the check is measuring the thing it claims to measure.

`black`, `isort`, `flake8` and `ssort` are clean on both changed files.

## What this does NOT do

It does not stop the duplicate request from being sent. The membership check exists (`target.difference(current)`) but compares against a cached album snapshot, so a share made outside the tool within the cache window is invisible to it. That is a separate change — it touches caching, which affects the performance of the whole pass — and it is worth landing this isolation first regardless of how that one turns out.