### PR TITLE
docs gate: give the web axis a token — the problem was quota, not permissions

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -23,4 +23,21 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: darnlink docs-link gate
+        # GITHUB_TOKEN for the WEB axis — and the reason is QUOTA, not permissions.
+        # This repo is public and its cross-repo links point only at itself, so the
+        # probe needs no privileges. What it needs is a rate limit: anonymous API
+        # calls are capped at 60/h PER PUBLIC IP, shared by everything behind it.
+        # Measured on this repo, same tree, minutes apart:
+        #     without token -> ok 0 | unverifiable 52
+        #     with token    -> ok 7 | unverifiable 45
+        # The zero is not "nothing to check": it is "could not look". With the
+        # bucket empty, a repo with no cross-repo links and one whose probe was
+        # throttled report the same reassuring number — the axis silently stops
+        # verifying while the build stays green. The automatic token raises the
+        # limit to 1000/h and makes the result deterministic instead of a function
+        # of what time the build ran.
+        # (The 45 that stay unverifiable with a token are correct: they are not
+        # GitHub URLs — semver.org and friends — and this axis only reads GitHub.)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/devtools/darnlink_docs_gate.sh .

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -111,6 +111,16 @@ PY
 # online, tokenless). Anchored with `<!-- web-uuid: X -->`. Fail-closed on a broken cross-repo link.
 # Skippable offline (DARNLINK_SKIP_WEB=1, e.g. a disconnected pre-commit); pre-push/CI always has network.
 if [ "${DARNLINK_SKIP_WEB:-0}" != "1" ]; then
+	# ⚠️ SAY IT WHEN THE AXIS CANNOT ACTUALLY VERIFY. Anonymous GitHub API calls are
+	# capped at 60/h per public IP, shared by everything behind it. With the bucket
+	# empty this pass reports `ok 0 | unverifiable N` — which reads like "nothing to
+	# check" and is indistinguishable from a repo with no cross-repo links. It is not
+	# a failure (offline dev must still be able to commit), but an unannounced 0 is
+	# how a gate stops meaning anything. Measured here: 0 -> 7 verified with a token.
+	if [ -z "${GITHUB_TOKEN:-}" ]; then
+		echo "darnlink web axis: no GITHUB_TOKEN → running on the ANONYMOUS 60/h-per-IP quota." >&2
+		echo "  A result of 'ok 0' below means COULD NOT LOOK, not 'nothing to verify'." >&2
+	fi
 	# NO `exec`: reemplazaria la imagen del shell y el trap EXIT no correria, dejando
 	# el temporal de mktemp en cada ejecucion completa (medido: una fuga por push).
 	uvx --from "${DARNLINK_FROM}" darnlink web-check "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}" --online


### PR DESCRIPTION
## The finding

The web pass reported `ok 0 | unverifiable 52` and nobody noticed — because **a zero there reads like "nothing to check" when it means "could not look"**.

This repo is **public** and its cross-repo links point **only at itself**, so the probe never needed privileges. What it needs is a rate limit:

> Anonymous GitHub API calls are capped at **60/h per public IP**, shared by everything behind it.

```
without token -> ok 0 | unverifiable 52
with token    -> ok 7 | unverifiable 45
```

**Confirmed in CI on this PR: the run now reports `ok 7`.** The remaining 45 are correct — not GitHub URLs (`semver.org` and friends), and this axis only reads GitHub.

## Two changes

| Where | What |
|---|---|
| **GitHub Actions** | `env: GITHUB_TOKEN` from the automatic secret — enough **precisely because** the links stay inside this public repo |
| **The script** | now **says so** when it runs without a token, instead of printing a quiet zero |

The second is the real fix. Not a failure — committing offline must keep working — but **an unannounced 0 is how a gate stops meaning anything**: a repo with no cross-repo links and a throttled probe produce the same reassuring number.

```
darnlink web axis: no GITHUB_TOKEN → running on the ANONYMOUS 60/h-per-IP quota.
  A result of 'ok 0' below means COULD NOT LOOK, not 'nothing to verify'.
```

**The token makes today's result correct; the warning makes tomorrow's result readable.**

## Jenkins is left out on purpose

The agent shares the public IP, so it is the surface **most** exposed to an empty bucket — it *should* have the token. But the only credential available is `withCredentials(credentialsId: …)`, and **that id embeds the CI host's internal name**. Adding a second occurrence is a new private reference in a public repo, and the privacy gate caught exactly that (`Jenkinsfile:191`).

The first occurrence is tolerated via `.github/privacy-gate-baseline.txt`, whose own header says the list *"may only shrink. Adding to it means letting a new leak through."*

So the fix is the infrastructure change **that baseline already prescribes**: re-create the credential in Jenkins under a neutral id, point the Jenkinsfile at it, delete the old one, drop the baseline line. Doing it the easy way would have traded a real privacy boundary for a convenience.

## Verification

```
without token -> warning printed, rc=0
with token    -> no warning, ok 0 -> 7, rc=0
in CI         -> ok 7, darnlink SUCCESS, scan SUCCESS
```