### PR TITLE
fix: shfmt formatting in the docs gate — it turned main red and hid the new gate

### DIFF
--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -91,8 +91,9 @@ uvx --from "${DARNLINK_FROM}" darnlink "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}" 
 # mktemp, NOT a fixed /tmp path: the pre-commit and pre-push hooks run on developer
 # machines where several worktrees can commit at once, and a shared path lets one run
 # overwrite another's report -- a red build could read a clean JSON and go green.
-DL_JSON="$(mktemp)"; trap 'rm -f "${DL_JSON}"' EXIT
-uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}" --json > "${DL_JSON}"
+DL_JSON="$(mktemp)"
+trap 'rm -f "${DL_JSON}"' EXIT
+uvx --from "${DARNLINK_FROM}" darnlink check "${SCAN_ROOT}" "${DARNLINK_EXCLUDES[@]}" --json >"${DL_JSON}"
 python3 - "${DL_JSON}" <<'PY'
 import json, sys
 d = json.load(open(sys.argv[1]))


### PR DESCRIPTION
`main` has been red since the dangling axis landed, and the cause is mine: `check_shfmt` flags three lines I added to `scripts/devtools/darnlink_docs_gate.sh`.

```diff
-DL_JSON="$(mktemp)"; trap 'rm -f "${DL_JSON}"' EXIT
-uvx ... --json > "${DL_JSON}"
+DL_JSON="$(mktemp)"
+trap 'rm -f "${DL_JSON}"' EXIT
+uvx ... --json >"${DL_JSON}"
```

Formatting, not logic. Applied with `shfmt -w -i 0` on that file only, so the diff is **the tool's own output** rather than my guess at its rules.

## ⚠️ The part that matters more than the fix

**This pipeline stops at the first failing stage.** `check_shfmt` is stage 157; `Quality Gate (Docs Links)` — the darnlink gate this whole change exists to add — is at **176**.

So for the last day **the new gate has not run once**. A green build after this commit is the first real evidence it works on CI at all.

That is exactly the warning written into this repo's own plan — *"check that the STAGE EXECUTES, not that the build is green"* — and then walked into: the gate was verified locally, **GitHub Actions was green** (a different surface, which does run it), and nobody checked the Jenkins stage had been *reached*.

## Deliberately not touched

`docker/cron-entrypoint.sh`, `run_app.sh`, `setup_venv.sh` and `immich_api_examples/run_test_asset_albums_tags.sh` are also unformatted — but the gate globs `find scripts -type f -name "*.sh"`, so they are out of scope. Reformatting them in a red-main fix would be unrelated churn.

## Verification

```
shfmt -l -i 0 over everything under scripts/  -> empty
bash -n                                       -> clean
the gate itself                               -> rc=0, "dangling: 0 -> ok"
```