### PR TITLE
uuid: the release announcement is linked from other repos by URL

### DIFF
--- a/docs/releases/v0.80.0-announcement.md
+++ b/docs/releases/v0.80.0-announcement.md
@@ -1,3 +1,7 @@
+---
+uuid: 2d7925b6-3638-4bda-8b25-78c9fc20cf0c
+---
+
 ## v0.80.0 — 2026-03-31
 
 # Immich AutoTag v0.80.0 – User Groups, Smarter Rule Engine, & Advanced Album Automation!


### PR DESCRIPTION
Three cross-repo links in other repositories point at `docs/releases/v0.80.0-announcement.md` by GitHub URL. darnlink can only make such a link robust — survive a rename of the destination — if the destination carries a `uuid` in its frontmatter.

Without one, the web axis stays **silent**: there is nothing to anchor to, so nothing is reported and the links stay plain URLs that break on the next move. This is the blind spot that darnlink's feature 016 is being built to surface; the fix for these three is simply to add the uuid.

One line, inert to everything else.