### PR TITLE
lang: gate the surfaces this repo's own check cannot see

### DIFF
--- a/.github/workflows/lang-surfaces.yml
+++ b/.github/workflows/lang-surfaces.yml
@@ -1,0 +1,69 @@
+# English-only on the surfaces this repo's own gate cannot see.
+#
+# ⚠️ THIS DOES NOT REPLACE `check_no_spanish_chars`, and nothing here touches it. That check is
+# BETTER than darnlang on files: it reads every tracked file rather than a chosen list of
+# extensions, it judges file NAMES, and it carries a curated wordlist plus an optional langdetect
+# layer. It stays exactly as it is, in Jenkins, where it already runs.
+#
+# What no file gate can see is what is written straight into GitHub. Measured on 2026-08-13 with
+# THIS repo's own detector, while the file gate was green: 42 lines across the last 400 commit
+# messages, 1 of 10 issues, and 10 of 60 pull requests. Those are also the least retractable
+# surfaces there are — an indexed pull-request title cannot be withdrawn, and editing it leaves the
+# previous text readable through the API.
+#
+# The detector is darnlang with THIS repo's wordlist added to its built-in one, so the policy stays
+# here and only the plumbing is shared. Measured before wiring it: the built-in list alone misses
+# `bloquea`/`calidad` (this repo's words), and this repo's list alone misses `el`/`que`/`la` (the
+# commonest markers there are). Each covers the other's gap; neither alone is enough.
+name: lang-surfaces
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  surfaces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # the commit-message step needs a range to walk
+      - uses: astral-sh/setup-uv@v5
+
+      # Resolve in a step of its OWN. `uvx --from <ref> darnlang …` in one call cannot tell "could
+      # not resolve" (uvx exits 1) from "found something" (darnlang exits 1), and conflating them
+      # turns a network hiccup into a language finding.
+      - name: Install darnlang
+        run: |
+          . tools/darnlang_ref.sh
+          uv tool install "$DARNLANG_REF"
+
+      # ONE MESSAGE AT A TIME. Concatenating the range and judging it as one text is how a single
+      # English line hides a Spanish one.
+      - name: Commit messages added by this push or PR
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            RANGE="${{ github.event.after }} -1"
+          else
+            RANGE="${{ github.event.before }}..${{ github.event.after }}"
+          fi
+          fail=0
+          while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            git log -1 --format=%B "$sha" > "$RUNNER_TEMP/one.txt"
+            darnlang prose "$RUNNER_TEMP/one.txt" --label "commit message $sha" || fail=1
+          done < <(git log --format=%H $RANGE)
+          exit "$fail"
+
+      # Through the environment, never interpolated into `run:` — a title is attacker-controlled on
+      # a public repo, and `run: echo "${{ github.event… }}"` is a shell injection.
+      - name: PR title and description
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > "$RUNNER_TEMP/pr.txt"
+          darnlang prose "$RUNNER_TEMP/pr.txt" --label "PR title/description"

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# darnlang, pinned — used ONLY for the surfaces this repo's own gate cannot see.
+#
+# ⚠️ THIS DOES NOT REPLACE `check_no_spanish_chars`. That check is better than darnlang on files:
+# it reads every tracked file rather than a chosen list of extensions, it judges file NAMES, and it
+# carries a curated 100-word list plus an optional langdetect layer. It stays exactly as it is.
+#
+# What it cannot see is what is written straight into GitHub — commit messages, pull-request titles
+# and descriptions, issues. Measured with this repo's OWN detector on 2026-08-13: 42 lines across
+# the last 400 commit messages, 1 of 10 issues and 10 of 60 pull requests, with the file gate green
+# the whole time. Those surfaces are also the least retractable: an indexed PR title cannot be
+# withdrawn.
+#
+# darnlang is told to use THIS repo's wordlist (`--words-file`), so the policy stays here and only
+# the plumbing is shared. One tool for the surface nobody was watching, not a second opinion about
+# the files.
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.6.0"
+export DARNLANG_WORDS="$(git rev-parse --show-toplevel)/scripts/devtools/spanish_words.txt"


### PR DESCRIPTION
**Nothing here replaces or touches `check_no_spanish_chars`.** That check is *better* than the tool this PR adds, on files: it reads every tracked file rather than a chosen list of extensions, it judges file **names**, and it carries a curated wordlist plus an optional `langdetect` layer. It keeps running in Jenkins exactly as today.

## What it cannot see

Measured with **this repo's own detector**, while the file gate was green:

| Surface | In Spanish |
|---|---|
| tracked files | **1 line** — the check works |
| commit messages (last 400) | **42 lines** |
| issues | **1 of 10** |
| pull requests | **10 of 60** |

Those are the least retractable surfaces there are: an indexed PR title cannot be withdrawn, and editing it leaves the previous text readable through the API.

## Why the two wordlists are combined

The configuration was chosen by measurement, not preference:

| Text | this repo's list alone | built-in alone | combined |
|---|---|---|---|
| `corrige el fallo que rompia la ejecucion` | **missed** | caught | **caught** |
| `bloquea cuando la calidad no es suficiente` | caught | **missed** | **caught** |
| `fix: shfmt formatting in the docs gate` | clean | clean | **clean** |

This repo's list is **content** words; the built-in one is **function** words — the commonest markers there are. Each covers the other's gap. The policy stays in `scripts/devtools/spanish_words.txt`; only the plumbing is shared.

## Three details that already cost sibling repos real defects

- **Resolve in a step of its own.** `uvx --from <ref> tool …` in one call cannot tell *"could not resolve"* (uvx exits 1) from *"found something"* (the tool exits 1). On an issue workflow that difference is a public comment accusing a stranger.
- **One commit message at a time.** Concatenating the range and judging it as a single text lets one English line hide a Spanish one — measured.
- **Attacker-controlled text through `env:`**, never interpolated into `run:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)