### PR TITLE
web: anchor the three cross-repo links to the release announcement

### DIFF
--- a/docs/issues/0033-community/subtasks/0011-announcement-tracking/github-discussions/2026-03-31-announcement_2026.md
+++ b/docs/issues/0033-community/subtasks/0011-announcement-tracking/github-discussions/2026-03-31-announcement_2026.md
@@ -37,7 +37,7 @@ Tracked at [GitHub Issue #43](https://github.com/txemi/immich-autotag/issues/43)
 
 ## Get Started
 
-- 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md)
+- 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md) <!-- web-uuid: 2d7925b6-3638-4bda-8b25-78c9fc20cf0c -->
 - 🏠 [Homepage](https://github.com/txemi/immich-autotag)
 - 📖 [Quick Start (README)](https://github.com/txemi/immich-autotag#quick-start)
 - 📋 [Full Changelog](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md) <!-- web-uuid: 2582dca7-b9de-491d-a906-7603c2d682b8 -->

--- a/docs/issues/0033-community/subtasks/0011-announcement-tracking/linkedin/2026-03-31-announcement.md
+++ b/docs/issues/0033-community/subtasks/0011-announcement-tracking/linkedin/2026-03-31-announcement.md
@@ -39,7 +39,7 @@ Testing this software against my own infrastructure of **360k+ assets** allowed 
 Whether you’re into Open Source, data management at scale, or just want to regain control of your digital life, this release is for you.
 
 👇 **Check out the full technical breakdown and the "Deep Dive" in the repository:**
-- 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md)
+- 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md) <!-- web-uuid: 2d7925b6-3638-4bda-8b25-78c9fc20cf0c -->
 - 🏠 [Homepage](https://github.com/txemi/immich-autotag)
 
 #OpenSource #Immich #SelfHosted #Engineering #CloudArchitecture #Automation #SoftwareDevelopment #DataGovernance #Scalability #DataIntegrity

--- a/docs/releases/v0.80.0-announcement.md
+++ b/docs/releases/v0.80.0-announcement.md
@@ -33,7 +33,7 @@ Tracked at [GitHub Issue #43](https://github.com/txemi/immich-autotag/issues/43)
 
 ## Get Started
 
-- 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md)
+- 🔗 [Official Announcement URL](https://github.com/txemi/immich-autotag/blob/main/docs/releases/v0.80.0-announcement.md) <!-- web-uuid: 2d7925b6-3638-4bda-8b25-78c9fc20cf0c -->
 - 🏠 [Homepage](https://github.com/txemi/immich-autotag)
 - 📖 [Quick Start (README)](https://github.com/txemi/immich-autotag#quick-start)
 - 📋 [Full Changelog](https://github.com/txemi/immich-autotag/blob/main/CHANGELOG.md) <!-- web-uuid: 2582dca7-b9de-491d-a906-7603c2d682b8 -->


### PR DESCRIPTION
Follow-up to #78, which gave `docs/releases/v0.80.0-announcement.md` a `uuid`.

Three links in this repository point at that file **by GitHub URL** rather than by relative path. Until it had a `uuid` there was nothing to anchor them to, so darnlink reported **nothing**: a destination without a `uuid` produces no finding at all, which is precisely the blind spot the tool's feature 016 is being built to surface.

With the anchor in place each link resolves through the destination's `uuid` rather than its path, so a rename no longer breaks it.

Written by `darnlink web-check --online --write` (v0.20.5), so the uuids are **read from the destination**, not typed by hand — an anchor carrying an invented uuid passes every gate green while pointing at nothing, and that failure stays invisible until someone renames the file.

Verified three ways, byte for byte, that the anchored uuid is the destination's: on disk, in `origin/main`, and through the GitHub Contents API — the last one being what `web-check` will see from any other machine. Re-running the tool reports the three as `web_ok` (*"anchored uuid matches destination"*) and writes nothing, so it is idempotent.