### PR TITLE
lang: correct the wordlist claim, and bump the pin (version hygiene, not an exposure fix here)

### DIFF
--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -11,8 +11,17 @@
 # the whole time. Those surfaces are also the least retractable: an indexed PR title cannot be
 # withdrawn.
 #
-# darnlang is told to use THIS repo's wordlist (`--words-file`), so the policy stays here and only
-# the plumbing is shared. One tool for the surface nobody was watching, not a second opinion about
-# the files.
+# This repo's wordlist DOES reach darnlang, but not the way the two lines above used to claim.
+# Nothing passes `--words-file`; grep the workflows and it is simply absent. What actually happens
+# is AUTO-DETECTION: `scripts/devtools/spanish_words.txt` is one of the filenames darnlang looks for
+# on its own, and it says so out loud on every run ("adding 100 word(s) from …").
+#
+# The difference is not academic and it runs the other way from the old comment:
+#   `--words-file`   REPLACES the built-in list  -> this repo's 100 words, and nothing else
+#   auto-detection   ADDS to the built-in list   -> this repo's 100 words PLUS the shared ones
+# Auto-detection is the behaviour we want here. But it is bound to the FILENAME, so renaming or
+# moving that file drops the 100 words in silence, and the variable below will not save it — it is
+# read by nobody. Kept, and labelled, because deleting it would hide where the list lives.
 export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.7.0"
+# Documentation only: darnlang finds this path by name, it is not passed as a flag anywhere.
 export DARNLANG_WORDS="$(git rev-parse --show-toplevel)/scripts/devtools/spanish_words.txt"

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -14,5 +14,5 @@
 # darnlang is told to use THIS repo's wordlist (`--words-file`), so the policy stays here and only
 # the plumbing is shared. One tool for the surface nobody was watching, not a second opinion about
 # the files.
-export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.6.0"
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.7.0"
 export DARNLANG_WORDS="$(git rev-parse --show-toplevel)/scripts/devtools/spanish_words.txt"


### PR DESCRIPTION
## What this changes

Two things, both surfaced by an adversarial review of what started as a one-line pin bump.

### 1. The header described a mechanism this repo does not use

`tools/darnlang_ref.sh` claimed darnlang is told to use this repo's wordlist via `--words-file`.
**Nothing passes that flag** — it is absent from every workflow. The list does reach darnlang, but
by **auto-detection on the filename**, which the tool announces on every run (`adding 100 word(s)
from …`). And the two mechanisms differ in the *opposite* direction from what the comment implied:

| Mechanism | Effect |
|---|---|
| `--words-file` | **replaces** the built-in list |
| auto-detection (what actually happens) | **adds** to the built-in list |

Auto-detection is the behaviour we want. The cost, now written down: it is bound to the filename, so
renaming or moving `scripts/devtools/spanish_words.txt` drops the 100 words silently.

### 2. The pin bump is correct, but its original rationale was false *for this repo*

The first version of this PR argued that `v0.7.0` matters because it seeds `langdetect`, and that a
finding on the issue surface posts a public comment. **Measured here, none of that applies:**

- there is **no issue workflow** (`.github/workflows/` = `docs-links`, `lang-surfaces`,
  `privacy-gate`, `release`; none triggers on `issues`);
- **`--strict` is passed nowhere** — `lang-surfaces.yml:56` and `:69` run `darnlang prose --label`;
- the **`[strict]` extra is not installed** — line 39 is `uv tool install "$DARNLANG_REF"`.

`langdetect_is_foreign` is unreachable here, so the seed changes nothing. The bump is **version
hygiene**, and it is worth doing on that basis alone. The repo that genuinely had that exposure is
**public `darnlink`**, which was still on `v0.4.0`; it is being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)