### PR TITLE
lang: stop lang-surfaces.yml from tripping the file gate on its own examples

### DIFF
--- a/.github/workflows/lang-surfaces.yml
+++ b/.github/workflows/lang-surfaces.yml
@@ -12,14 +12,17 @@
 # previous text readable through the API.
 #
 # The detector is darnlang with THIS repo's wordlist added to its built-in one, so the policy stays
-# here and only the plumbing is shared. Measured before wiring it: the built-in list alone misses
-# the domain words kept in `scripts/devtools/spanish_words.txt`, and that file alone misses the
-# commonest grammatical markers, which the built-in list does carry. Each covers the other's gap;
-# neither alone is enough.
+# here and only the plumbing is shared. Measured before wiring it against the pinned v0.7.0: the
+# built-in list alone misses 94 of the 100 words kept in `scripts/devtools/spanish_words.txt` (the
+# 6 it does carry are grammatical markers, not domain words), and that file alone misses 45 of the
+# 51 commonest grammatical markers, which the built-in list does carry. Each covers the other's
+# gap; neither alone is enough.
 #
 # No sample word is quoted in this file on purpose. `check_no_spanish_chars` reads every tracked
-# file, this one included, and cannot tell a quoted example from a violation — quoting two of them
-# here is what turned the Jenkins pipeline red on 2026-08-14.
+# file, this one included, and has NO general "this is only an example" marker: its single per-line
+# opt-out is the literal `SPANISH_PATTERN=`, reserved for the shell gate's own regex. So a quoted
+# sample here is indistinguishable from a violation — quoting two of them is what turned the
+# Jenkins pipeline red when #79 landed on 2026-08-13 (spotted on the master a day later).
 name: lang-surfaces
 
 on:

--- a/.github/workflows/lang-surfaces.yml
+++ b/.github/workflows/lang-surfaces.yml
@@ -13,8 +13,13 @@
 #
 # The detector is darnlang with THIS repo's wordlist added to its built-in one, so the policy stays
 # here and only the plumbing is shared. Measured before wiring it: the built-in list alone misses
-# `bloquea`/`calidad` (this repo's words), and this repo's list alone misses `el`/`que`/`la` (the
-# commonest markers there are). Each covers the other's gap; neither alone is enough.
+# the domain words kept in `scripts/devtools/spanish_words.txt`, and that file alone misses the
+# commonest grammatical markers, which the built-in list does carry. Each covers the other's gap;
+# neither alone is enough.
+#
+# No sample word is quoted in this file on purpose. `check_no_spanish_chars` reads every tracked
+# file, this one included, and cannot tell a quoted example from a violation — quoting two of them
+# here is what turned the Jenkins pipeline red on 2026-08-14.
 name: lang-surfaces
 
 on:

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -22,6 +22,12 @@
 # Auto-detection is the behaviour we want here. But it is bound to the FILENAME, so renaming or
 # moving that file drops the 100 words in silence, and the variable below will not save it — it is
 # read by nobody. Kept, and labelled, because deleting it would hide where the list lives.
+#
+# ⚠️ DO NOT QUOTE A SAMPLE WORD ANYWHERE IN THIS FILE. It is tracked, so `check_no_spanish_chars`
+# scans it like any other, and it has no general "this is only an example" marker — the single
+# per-line opt-out is the literal `SPANISH_PATTERN=`, reserved for the shell gate's own regex.
+# Quoting two samples in the twin comment of `.github/workflows/lang-surfaces.yml` is what turned
+# four Jenkins rows red on 2026-08-13. Name the list file instead; that is what it is for.
 export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.7.0"
 # Documentation only: darnlang finds this path by name, it is not passed as a flag anywhere.
 export DARNLANG_WORDS="$(git rev-parse --show-toplevel)/scripts/devtools/spanish_words.txt"


### PR DESCRIPTION
`check_no_spanish_chars` reads every tracked file, this workflow included, and cannot tell a quoted example from a violation. Two sample words quoted in the header comment matched the wordlist, so the Jenkins pipeline went red with the gate reporting its own documentation.

Red rows this unblocks (measured on the Jenkins master, 2026-08-14):

| row | last result |
|---|---|
| `immich-autotag / main` | FAILURE — `[EXIT] Stopped at check: check_no_spanish_chars with 2 errors` |
| `immich-autotag / ops/batch-processing` | same |
| `immich-autotag / PR-81` | same |
| `immich-autotag / PR-82` | same |

## What changed

The header comment points at `scripts/devtools/spanish_words.txt` instead of quoting sample words, and states in the file why no sample is quoted — so the next edit does not reintroduce it. No behaviour change: the workflow body is untouched.

## Verification

Replayed the check's STANDARD logic (forbidden-byte scan + word-boundary wordlist match, same exclusions) over all 591 tracked files: **0 findings**. Before the change the same replay reproduced the 2 the pipeline reported.

Not covered: the Jenkins run itself, which only happens after this lands.