### PR TITLE
ci: only the operational branch runs the application

### DIFF
--- a/.github/privacy-gate-baseline.txt
+++ b/.github/privacy-gate-baseline.txt
@@ -7,4 +7,4 @@
 # exactly this id, so editing the string alone breaks tag pushing. Clearing it is an infrastructure
 # change, in this order: create the credential again in Jenkins under a neutral id, point the
 # Jenkinsfile at it, delete the old one, then delete this line.
-Jenkinsfile:22
+Jenkinsfile:29

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,14 @@ def ENABLE_JENKINS_TAGGING = true // Set to true to enable GitHub tagging
 // branch it would spin a second infinite loop competing for the SAME single agent
 // (the one carrying the `immich-batch` label), where each run can take hours. main is
 // for validating, not for processing the library.
-def ENABLE_AUTO_CHAIN = (env.BRANCH_NAME == 'ops/batch-processing')
+// ONE literal for "the operational branch". Two copies of this string would drift, and
+// the drift is not benign: if only one is updated on a rename, the chain keeps
+// re-triggering while the application never runs -- an endless run of 7-minute GREEN
+// builds that process nothing and push a git tag per cycle. A different branch name for
+// this same role is still referenced by an enabled scheduler entry, so the rename is not
+// hypothetical.
+def OPS_BRANCH = 'ops/batch-processing'
+def ENABLE_AUTO_CHAIN = (env.BRANCH_NAME == OPS_BRANCH)
                                   // (keeps the batch-processing chain self-perpetuating
                                   // without external dispatch). Failure stops the chain
                                   // by design — re-enable manually after investigating.
@@ -211,8 +218,10 @@ pipeline {
             // Only the operational branch touches the real library. Every other branch
             // -- main, PRs, worktrees -- stops after the gates.
             //
-            // Same condition that already drives ENABLE_AUTO_CHAIN, on purpose: "this is
-            // the operational branch" is ONE fact, and two copies of it would drift.
+            // Uses the SAME variable and the SAME comparison as ENABLE_AUTO_CHAIN, not a
+            // second copy of the string: "this is the operational branch" has to be one
+            // fact. `when { branch '...' }` would have been a second copy AND a second
+            // mechanism (ANT glob instead of `==`).
             //
             // Measured before adding this (2026-08-11/13), with PR and main builds
             // running the app against the same Immich as the batch chain:
@@ -227,7 +236,7 @@ pipeline {
             // tags, albums and SHARING PERMISSIONS to a real family photo library. And
             // it made CI failures and production failures the same failure -- a Spanish
             // word in a YAML comment stopped photo classification for a day.
-            when { branch 'ops/batch-processing' }
+            when { expression { env.BRANCH_NAME == OPS_BRANCH } }
             steps {
                 script {
                     echo "Running immich-autotag application..."
@@ -250,7 +259,17 @@ pipeline {
             //     time (5-47h per build for the post-actions phase). We don't
             //     consume these artifacts across pipelines, so the fingerprints
             //     have no consumer.
-            archiveArtifacts artifacts: 'logs_local/*_PID*/**', excludes: 'logs_local/*/api_cache/**', fingerprint: false, allowEmptyArchive: true
+            // Only archive where the application actually ran. The workspace is
+            // persistent and `logs_local/` survives across builds, so on a branch that
+            // stops at the gates this would publish ANOTHER build's run directories --
+            // measured on main #50: 30 files from 5 stale runs, up to 4 days old,
+            // including `run_statistics.yaml`, presented as if this build had produced
+            // them. Intermittent before the `when` above; the steady state after it.
+            script {
+                if (env.BRANCH_NAME == OPS_BRANCH) {
+                    archiveArtifacts artifacts: 'logs_local/*_PID*/**', excludes: 'logs_local/*/api_cache/**', fingerprint: false, allowEmptyArchive: true
+                }
+            }
             echo "Pipeline execution completed at ${new Date()}"
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,6 +208,26 @@ pipeline {
 
 
         stage('Run Application') {
+            // Only the operational branch touches the real library. Every other branch
+            // -- main, PRs, worktrees -- stops after the gates.
+            //
+            // Same condition that already drives ENABLE_AUTO_CHAIN, on purpose: "this is
+            // the operational branch" is ONE fact, and two copies of it would drift.
+            //
+            // Measured before adding this (2026-08-11/13), with PR and main builds
+            // running the app against the same Immich as the batch chain:
+            //   chain alone .............. 0.052 s/asset
+            //   chain + a PR classifying .. 2.253 s/asset   (43x)
+            //   chain + main classifying .. 5.040 s/asset   (70x)
+            // Two builds also fork the checkpoint: Jenkins hands the second one a
+            // `@2` workspace, and skip_n lives in the workspace, so they walk the
+            // library independently without knowing about each other.
+            //
+            // The other half is worse than slowness: a PR is unreviewed code writing
+            // tags, albums and SHARING PERMISSIONS to a real family photo library. And
+            // it made CI failures and production failures the same failure -- a Spanish
+            // word in a YAML comment stopped photo classification for a day.
+            when { branch 'ops/batch-processing' }
             steps {
                 script {
                     echo "Running immich-autotag application..."


### PR DESCRIPTION
## The problem

`Run Application` had no condition, so **every** branch ran it against the real Immich library — `main`, PRs, worktrees. Nothing said otherwise, so nothing stopped them.

### Speed

Measured 2026-08-11 and 08-13, with the batch chain and other builds sharing one agent and one Immich:

| | s/asset |
|---|---|
| chain alone | **0.052** |
| chain + a PR classifying | 2.253 — **43×** |
| chain + `main` classifying | 5.040 — **70×** |

Concurrent builds also **fork the checkpoint**: Jenkins hands the second one a `@2` workspace, and `skip_n` lives in the workspace. So two builds walk the library independently and neither knows about the other. That is not duplicated work, it is a forked traversal.

### Correctness — the part that matters more

A PR is **unreviewed code writing tags, albums and sharing permissions** to a real photo library.

And it made CI failures and production failures the same failure: a Spanish word inside a YAML comment stopped photo classification for a day, because one pipeline both verified the code and did the work.

## Why a `when`, and not a parameter or a second Jenkinsfile

- **A parameter needs someone to set it**, and nothing here does — the auto-chain, branch indexing and PR triggers all use the default. In multibranch the **first build of a new branch always takes defaults**, so every new PR would classify anyway. It also adds a human failure mode: a manual run with the wrong value writes to the real library from any branch.
- **A second Jenkinsfile duplicates the gate stages**, and drift between copies is a problem this codebase already has — the language gate is vendored in four repos and has **diverged in three lines**. In a gate, that means two copies disagreeing about what "green" means.
- **The `when` reuses the condition `ENABLE_AUTO_CHAIN` already tests.** "This is the operational branch" stays **one fact** instead of two that can fall out of sync.

## Verification

Validated against the running Jenkins via `pipeline-model-converter/validate` — not just read. Behaviour is observable on the next build of any non-operational branch: the stage should report as skipped and the build should finish in minutes instead of hours.

## Deliberately not in this PR

The operational branch can still **overlap itself** when a build waits for an executor while the chain fires the next one. That needs `disableConcurrentBuilds()` — a different decision about a different scope, and worth its own review.