### PR TITLE
ci: one build per branch at a time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,24 @@ pipeline {
         // success post-action below), so old builds never rotated and ate
         // tens of GB on the master.
         buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '30'))
+        // One build per branch at a time. This is NOT about tidiness: the checkpoint
+        // (`skip_n`) lives in `logs_local/` INSIDE the workspace, and when two builds of
+        // the same branch overlap, Jenkins hands the second one a separate `@2`
+        // workspace -- so they do not duplicate work, they FORK the traversal, and
+        // neither knows the other exists.
+        //
+        // It happens without anyone doing anything wrong: a build waits for the single
+        // executor while the auto-chain fires the next one. Seen 2026-08-12, builds #369
+        // and #371 -- the second died 30 min in with "process apparently never started"
+        // in its `@2` workspace, after rebuilding the album map for nothing.
+        //
+        // Scope is exactly right here: `disableConcurrentBuilds()` acts PER JOB, and in a
+        // multibranch job that is per branch. It was considered and rejected earlier for
+        // a different question -- stopping `main` and the operational branch from
+        // competing -- where it does nothing, because those are different jobs. Rejecting
+        // an option answers ONE question; it has to be reconsidered when the question
+        // changes.
+        disableConcurrentBuilds()
     }
     agent {
         docker {


### PR DESCRIPTION
## Why

The checkpoint (`skip_n`) lives in `logs_local/` **inside the workspace**. When two builds of the same branch overlap, Jenkins hands the second one a separate `@2` workspace — so they do not duplicate work, they **fork the traversal**, and neither knows the other exists.

It happens without anyone doing anything wrong: a build waits for the single executor while the auto-chain fires the next one on success.

**Observed 2026-08-12**, builds #369 and #371: the second died 30 minutes in with `process apparently never started` inside its `@2` workspace, after rebuilding the album map for nothing.

## Why this option, now

`disableConcurrentBuilds()` acts **per job**, and in a multibranch job that is **per branch** — exactly the scope of the problem.

It was **considered and rejected** a few days ago for a *different* question: stopping the default branch and the operational one from competing. There it does nothing, because those are different jobs; that one was fixed by gating the application stage on the branch. **Rejecting an option answers one question — it has to be reconsidered when the question changes.**

## Verification

- Validated against the running Jenkins via `pipeline-model-converter/validate`.
- **Checked that it does not shift the line covered by the privacy-gate baseline.** The added lines sit below it and the entry still resolves. That baseline is indexed by line number, so any edit *above* a covered line silently turns into a "new private reference" — which cost three blind attempts on the previous PR.

## What it does not do

It does not stop a build from *queueing*; it stops it from *running* alongside another of the same branch. With the single executor that is the behaviour we want: the chain serialises instead of forking.