### PR TITLE
lang: close the gap that published ad713a7a5, and pin v0.9.1

### DIFF
--- a/.github/workflows/lang-surfaces.yml
+++ b/.github/workflows/lang-surfaces.yml
@@ -28,6 +28,12 @@ name: lang-surfaces
 on:
   push:
   pull_request:
+    # `edited` is NOT decoration, and this repo is where its absence was measured. GitHub's default
+    # for `pull_request` is [opened, synchronize, reopened] -- so a body typed or rewritten AFTER the
+    # pull request was opened is never judged. This repo SQUASH-merges, so the body becomes the
+    # commit message: the gap publishes permanent history in the wrong language while every check
+    # shows green. That is precisely how ad713a7a5 got in on 2026-08-14, and it cannot be undone.
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   surfaces:

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -28,6 +28,6 @@
 # per-line opt-out is the literal `SPANISH_PATTERN=`, reserved for the shell gate's own regex.
 # Quoting two samples in the twin comment of `.github/workflows/lang-surfaces.yml` is what turned
 # four Jenkins rows red on 2026-08-13. Name the list file instead; that is what it is for.
-export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.9.0"
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.9.1"
 # Documentation only: darnlang finds this path by name, it is not passed as a flag anywhere.
 export DARNLANG_WORDS="$(git rev-parse --show-toplevel)/scripts/devtools/spanish_words.txt"


### PR DESCRIPTION
Two changes. The **first is the one that matters** — it closes the hole that let a fully non-English commit message into `main` yesterday.

## 1. The PR-text gate never re-ran when the body was edited

GitHub defaults `pull_request` to `[opened, synchronize, reopened]`. **`edited` is not in that list.** So a description typed or rewritten *after* the PR was opened was never judged — and the checks stayed green the whole time, because they had genuinely passed on the body that existed at open.

This repo **squash-merges**, so the body becomes the commit message. The gap therefore does not just miss a finding: it **publishes permanent history in the wrong language**, on a surface nobody can rewrite afterwards.

Measured, not theorised: **`ad713a7a5` (2026-08-14)** is a fully non-English commit message produced exactly this way — a verdict table written into a PR body after opening, then squashed into `main`.

`darnlang` and `darnlink` already carried `types: [opened, edited, reopened, synchronize]`. The recipe existed; three repos never got it. All three now have it.

## 2. Pin `v0.9.1`

Adds `scanned_names` to the baseline format upstream: until now the record held **extensions only**, so the extensionless CI files darnlang judges (`Jenkinsfile`, `Dockerfile`, …) had no representation, and losing that coverage would have read as *“it went DOWN, lock the win in”*.

This repo has no darnlang tree gate, so for it the bump is version hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)