### PR TITLE
darnlink: pin v0.24.0 (SHA c61a9e0b)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       # darnlink docs-link gate (max / fail-closed): fails the commit if any
       # internal Markdown link points at a file without a `uuid`, or if a
       # uuid-anchored link needs repair (e.g. a doc was moved). Read-only. Fix:
-      #   uvx --from "git+https://github.com/txemi/darnlink@v0.20.4" darnlink . --robustify --create-frontmatter --write
+      #   uvx --from "git+https://github.com/txemi/darnlink@v0.24.0" darnlink . --robustify --create-frontmatter --write
       - id: darnlink-docs-links
         name: darnlink docs-link gate
         # invoked via `bash` (not relying on the file's executable bit), matching

--- a/docs/issues/0031-cicd/subtasks/0014-quality-gate/subtasks/003-darnlink-docs-link-gate/README.md
+++ b/docs/issues/0031-cicd/subtasks/0014-quality-gate/subtasks/003-darnlink-docs-link-gate/README.md
@@ -30,7 +30,7 @@ editor lock-in. It is **not** a broken-link checker: it maintains the
 2. **Gate (ongoing):** `scripts/devtools/darnlink_docs_gate.sh` runs darnlink in
    its default *report* mode (no `--write`) over the repo. It exits non-zero if
    any anchored link needs repair, is unresolved, or a target has invalid
-   frontmatter. The darnlink version is pinned (`v0.20.4`).
+   frontmatter. The darnlink version is pinned (`v0.24.0`).
 
 ## Where it runs (one script, three gates)
 
@@ -45,7 +45,7 @@ editor lock-in. It is **not** a broken-link checker: it maintains the
 If the gate is red, a doc moved and a link is stale. Repair and commit:
 
 ```bash
-uvx --from "git+https://github.com/txemi/darnlink@v0.20.4" darnlink . --write
+uvx --from "git+https://github.com/txemi/darnlink@v0.24.0" darnlink . --write
 ```
 
 ## Status

--- a/hooks/pre-push.d/10-darnlink
+++ b/hooks/pre-push.d/10-darnlink
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # immich-autotag pre-push — WHOLE-REPO darnlink wall (piece 3 of 4), run by the global git-hooks
 # dispatcher (pre-push -> _dispatch). Mirrors the pre-commit-framework gate but for the push wall,
-# so nothing broken leaves the machine even if a commit used --no-verify. Same script, same v0.20.4 pin.
+# so nothing broken leaves the machine even if a commit used --no-verify. Same script, same v0.24.0 pin.
 # Bypass (discouraged): git push --no-verify
 set -euo pipefail
 root="$(git rev-parse --show-toplevel)"

--- a/scripts/devtools/darnlink_docs_gate.sh
+++ b/scripts/devtools/darnlink_docs_gate.sh
@@ -23,7 +23,7 @@
 # it additionally requires that *linkable* targets be uuid-bearing.
 # Exit 0 = clean, non-zero = findings. To fix locally (writes uuids):
 #
-#     uvx --from "git+https://github.com/txemi/darnlink@v0.20.4" darnlink . --robustify --create-frontmatter --write
+#     uvx --from "git+https://github.com/txemi/darnlink@v0.24.0" darnlink . --robustify --create-frontmatter --write
 #
 # Shared by the three gates so the logic lives in one place:
 #   - pre-commit  (.pre-commit-config.yaml)
@@ -49,7 +49,7 @@ set -euo pipefail
 # v0.16.0. A pin whose human-readable note lies is worse than one with no note --
 # it is what an auditor reads instead of resolving the SHA. When you bump the SHA
 # on the line below, bump BOTH mentions or neither.
-DARNLINK_REF="${DARNLINK_REF:-57f110fb665c826d560746ce86ebd22a92a78744}" # v0.20.4
+DARNLINK_REF="${DARNLINK_REF:-c61a9e0bf80e044f61d2ca2e00c2f1e84f6da6ea}" # v0.24.0
 DARNLINK_FROM="${DARNLINK_FROM:-git+https://github.com/txemi/darnlink@${DARNLINK_REF}}"
 SCAN_ROOT="${1:-.}"
 


### PR DESCRIPTION
## What

Bumps the darnlink pin (SHA-pinned, this is a public repo) to v0.24.0 in the two files that
declare it: `.pre-commit-config.yaml` (comment) and `scripts/devtools/darnlink_docs_gate.sh`
(the actual `DARNLINK_REF`).

Note: local `main` had diverged from `origin/main` by one stray local commit ("lang: pin
reaches v0.9.0", Aug 14) already superseded by squash-merged PR #85 (which landed as v0.9.1).
Reset local `main` to `origin/main` before branching — no content lost, it was already
integrated upstream.

## What v0.24.0 brings

D1a/D1b/D1c (fixes txemi/darnlink#65 #67 #41), D2 (defensive write guard), D3 (check+robustify
share a single tree parse, ~2.1x measured). Release: txemi/darnlink#94.

## Test plan
- [x] pre-commit passes locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)