### PR TITLE
ci: install ssort from PyPI instead of git+github

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pylint
-ssort @ git+https://github.com/bwhmather/ssort.git@0.16.0
+ssort==0.16.0
 
 # ruff 0.16.0 (jul-2026) enables new default rules (UP/RUF/PIE/BLE...) -> ~800
 # findings on this codebase and the Quality Gate fails. Pin below 0.16 until the


### PR DESCRIPTION
Build #407 of the batch-processing pipeline failed while installing dev
dependencies: `git clone ... ssort.git` exited 128, so `Failed to build 'ssort'`.
Builds #402-#406 were green — this is not the code.

The pin `ssort @ git+https://github.com/bwhmather/ssort.git@0.16.0` forces a
GitHub clone on every install, so any network hiccup on the agent takes the
build down before it reaches the quality gates.

`ssort 0.16.0` is published on PyPI (checked against the API: 0.13.0 .. 0.17.0),
so this switches to `ssort==0.16.0` — same exact version, nothing cloned.