### PR TITLE
ci: cap archived artifacts to the last 3 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,17 @@ pipeline {
         // pinned via `currentBuild.keepLog = true` (now removed in the
         // success post-action below), so old builds never rotated and ate
         // tens of GB on the master.
-        buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '30'))
+        // `artifactNumToKeepStr` is NOT redundant with `numToKeepStr`: the latter caps how many
+        // builds are kept, not how much they weigh. The `ops/batch-processing` branch archives
+        // its own run logs as artifacts (`logs_local/*_PID*/**`, ~345 MB per build, with single
+        // `modification_report.txt` files of 20-28 MB), so 30 retained builds are ~10 GB by
+        // design — not a leak. That is enough to fill a controller disk, and when it fills,
+        // Jenkins keeps assigning build numbers to runs it can no longer persist: they vanish
+        // without a log.
+        //
+        // Keeping 3 preserves all 30 builds and their console logs — the evidence — and drops
+        // only the artifacts of the older ones. Steady state: ~10 GB -> ~1 GB.
+        buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '30', artifactNumToKeepStr: '3'))
         // One build per branch at a time. This is NOT about tidiness: the checkpoint
         // (`skip_n`) lives in `logs_local/` INSIDE the workspace, and when two builds of
         // the same branch overlap, Jenkins hands the second one a separate `@2`


### PR DESCRIPTION
Limits archived artifacts to the **last 3 builds**.

## Why it is not cosmetic

The Jenkins agent disk reached **0 bytes free** this week and took down CI for every job on the
controller. 29 GB were recovered by hand, and the root cause was this repo archiving its own
`logs_local/*` without a cap (~345 MB per build). **This is the root fix for that.**

## What it does and does not touch

`artifactNumToKeepStr` acts **only** on archived artifacts. `numToKeepStr: '30'` stays untouched, so
**all 30 builds and their 30 console logs survive** — the console log is the primary diagnostic and
it is not affected.

## Reviewed twice, independently

**First review** measured the real build cadence on the branch that actually archives
(`ops/batch-processing`): the last 3 builds span **~21 hours**, not days. Worth knowing — `3` is
under a day of artifact retention. If that ever proves too short the answer is to **raise it to 8**
(~2.5 days), not to remove the cap.

⚠️ That review also **corrected its own first measurement**: an earlier figure of *"3 builds = 215
hours"* came from a job that has not built since March. **A dormant job yields a precise and false
cadence.**

**Second review, independent**, contrasted the first instead of assuming it, and added three things:

- `archiveArtifacts` is gated on `env.BRANCH_NAME == OPS_BRANCH`, so although `options{}` is global
  to the multibranch, **only that one branch archives anything** — no other branch is affected.
- The first review's search for consumers covered the plugin pattern (`copyArtifacts`) but **not
  HTTP consumption via the Jenkins API**. Re-running it with `/artifact/` found one real consumer
  elsewhere in the fleet — but it targets a **different job** and always `lastSuccessfulBuild`, so
  the cap does not reach it. **Conclusion held; the method was incomplete.**
- `fingerprint: false` is explicit, so no traceability is lost. And the batch resume checkpoint
  lives in the **workspace on disk**, not in the archived artifact, so the cap cannot break batch
  continuity.

**Not verified:** the `~21 hours` figure could not be re-checked by the second reviewer (no Jenkins
credentials in that context). It is context for *why 3 is enough*, not load-bearing for correctness —
the 30 console logs remain either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)