### PR TITLE
privacy gate: re-scan the PR body when it is edited

### DIFF
--- a/.github/workflows/privacy-gate.yml
+++ b/.github/workflows/privacy-gate.yml
@@ -29,7 +29,20 @@ name: privacy-gate
 on:
   push:
     branches: [main]
+  # `edited` and `reopened` are NOT in the default set (opened, synchronize, reopened) for `edited`,
+  # and both matter for the surface this gate calls the worst one.
+  #
+  # MEASURED 2026-08-22. This gate correctly blocked a merge because the PR body carried a private
+  # reference. The body was then corrected — and the check stayed red, because editing a PR body
+  # does not re-trigger `pull_request`. The only way to get it re-evaluated was to close and reopen
+  # the PR, which is not something anyone would guess.
+  #
+  # That failure mode is bad in both directions:
+  #   - a corrected body keeps showing as failing, so the gate looks broken and gets worked around;
+  #   - and a body edited AFTER a green run is never re-scanned at all, so a private reference can
+  #     be introduced post-approval and merged clean. That is the hole that matters.
   pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
The gate calls the PR title and body **"the worst surface"**, and says that catching a private
reference before merge **"is the only chance there is"**. It then does not listen to `edited` — so the
body, the one surface a human can change at any moment **without touching a commit**, is scanned once
and never again.

## Measured, 2026-08-22

The gate did its job: it blocked a merge because the PR body carried a private reference. The body
was then corrected — **and the check stayed red**, because editing a body does not re-trigger
`pull_request`. Getting it re-evaluated required **closing and reopening the PR**, which nobody
would guess.

## The failure mode is bad in both directions

| | |
|---|---|
| A **corrected** body keeps showing as failing | the gate looks broken, and people route around it |
| A body edited **after a green run** is never re-scanned | **a private reference can be introduced post-approval and merged clean** |

**The second one is the hole that matters**, and it is silent.

## The change

```yaml
pull_request:
  types: [opened, synchronize, reopened, edited, ready_for_review]
```

`ready_for_review` is in for the same reason: a draft promoted to ready is a surface that becomes
visible **without a push**.

The default set is written out explicitly rather than implied, so the next reader can see what is
covered without having to know what the default is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)